### PR TITLE
Make sure stack is aligned to 16 bytes

### DIFF
--- a/app/src/main/kotlin/compiler/intermediate/Constant.kt
+++ b/app/src/main/kotlin/compiler/intermediate/Constant.kt
@@ -16,9 +16,10 @@ class SummedConstant(private val first: Constant, private val second: Constant) 
     override val value get() = first.value + second.value
 }
 
-class ConstantAlignedToAGivenRestModulo(private val rawValue: Constant, private val modulo: Long, private val rest: Long = 0L) : Constant {
+class AlignedConstant(private val rawValue: Constant, private val modulo: Long, private val remainder: Long = 0L) : Constant {
+    // smallest number greater or equal to rawValue having a given remainder modulo
     override val value: Long get() {
-        val toAdd = rest - rawValue.value % modulo
+        val toAdd = remainder.mod(modulo) - rawValue.value % modulo
         return if (toAdd < 0) rawValue.value + toAdd + modulo
         else rawValue.value + toAdd
     }

--- a/app/src/main/kotlin/compiler/intermediate/Constant.kt
+++ b/app/src/main/kotlin/compiler/intermediate/Constant.kt
@@ -15,3 +15,11 @@ class SummedConstant(private val first: Constant, private val second: Constant) 
 
     override val value get() = first.value + second.value
 }
+
+class ConstantAlignedToAGivenRestModulo(private val rawValue: Constant, private val modulo: Long, private val rest: Long = 0L) : Constant {
+    override val value: Long get() {
+        val toAdd = rest - rawValue.value % modulo
+        return if (toAdd < 0) rawValue.value + toAdd + modulo
+        else rawValue.value + toAdd
+    }
+}

--- a/app/src/main/kotlin/compiler/intermediate/generators/DefaultFunctionDetailsGenerator.kt
+++ b/app/src/main/kotlin/compiler/intermediate/generators/DefaultFunctionDetailsGenerator.kt
@@ -3,6 +3,7 @@ package compiler.intermediate.generators
 import compiler.ast.NamedNode
 import compiler.ast.Variable
 import compiler.intermediate.CFGLinkType
+import compiler.intermediate.ConstantAlignedToAGivenRestModulo
 import compiler.intermediate.ConstantPlaceholder
 import compiler.intermediate.ControlFlowGraph
 import compiler.intermediate.ControlFlowGraphBuilder
@@ -67,7 +68,7 @@ data class DefaultFunctionDetailsGenerator(
         cfgBuilder.addLinksFromAllFinalRoots(
             CFGLinkType.UNCONDITIONAL,
             IFTNode.StackPush(IFTNode.RegisterRead(Register.RBP))
-        )
+        ) // disaligns stack
 
         // update rbp
         val movRbpRsp = IFTNode.RegisterWrite(
@@ -81,7 +82,14 @@ data class DefaultFunctionDetailsGenerator(
             Register.RSP,
             IFTNode.Subtract(
                 IFTNode.RegisterRead(Register.RSP),
-                IFTNode.Const(SummedConstant(variablesTotalOffset.toLong(), spilledRegistersOffset))
+                // make stack aligned back
+                IFTNode.Const(
+                    ConstantAlignedToAGivenRestModulo(
+                        SummedConstant(variablesTotalOffset.toLong(), spilledRegistersOffset),
+                        stackAlignmentInBytes.toLong(),
+                        stackAlignmentInBytes - memoryUnitSize.toLong()
+                    )
+                )
             )
         )
         cfgBuilder.addLinksFromAllFinalRoots(CFGLinkType.UNCONDITIONAL, subRsp)

--- a/app/src/main/kotlin/compiler/intermediate/generators/DefaultFunctionDetailsGenerator.kt
+++ b/app/src/main/kotlin/compiler/intermediate/generators/DefaultFunctionDetailsGenerator.kt
@@ -2,8 +2,8 @@ package compiler.intermediate.generators
 
 import compiler.ast.NamedNode
 import compiler.ast.Variable
+import compiler.intermediate.AlignedConstant
 import compiler.intermediate.CFGLinkType
-import compiler.intermediate.ConstantAlignedToAGivenRestModulo
 import compiler.intermediate.ConstantPlaceholder
 import compiler.intermediate.ControlFlowGraph
 import compiler.intermediate.ControlFlowGraphBuilder
@@ -68,7 +68,7 @@ data class DefaultFunctionDetailsGenerator(
         cfgBuilder.addLinksFromAllFinalRoots(
             CFGLinkType.UNCONDITIONAL,
             IFTNode.StackPush(IFTNode.RegisterRead(Register.RBP))
-        ) // disaligns stack
+        )
 
         // update rbp
         val movRbpRsp = IFTNode.RegisterWrite(
@@ -84,10 +84,10 @@ data class DefaultFunctionDetailsGenerator(
                 IFTNode.RegisterRead(Register.RSP),
                 // make stack aligned back
                 IFTNode.Const(
-                    ConstantAlignedToAGivenRestModulo(
+                    AlignedConstant(
                         SummedConstant(variablesTotalOffset.toLong(), spilledRegistersOffset),
                         stackAlignmentInBytes.toLong(),
-                        stackAlignmentInBytes - memoryUnitSize.toLong()
+                        stackAlignmentInBytes - 2 * memoryUnitSize.toLong() // -2 to account return address and backed up rbp
                     )
                 )
             )

--- a/app/src/main/kotlin/compiler/intermediate/generators/SysV64CallingConvention.kt
+++ b/app/src/main/kotlin/compiler/intermediate/generators/SysV64CallingConvention.kt
@@ -34,9 +34,12 @@ object SysV64CallingConvention {
             val toAdd = stackAlignmentInBytes - stackMovement % stackAlignmentInBytes
             cfgBuilder.addLinksFromAllFinalRoots(
                 CFGLinkType.UNCONDITIONAL,
-                IFTNode.Subtract(
-                    IFTNode.RegisterRead(Register.RSP),
-                    IFTNode.Const(toAdd)
+                IFTNode.RegisterWrite(
+                    Register.RSP,
+                    IFTNode.Subtract(
+                        IFTNode.RegisterRead(Register.RSP),
+                        IFTNode.Const(toAdd)
+                    )
                 )
             )
             stackMovement += toAdd

--- a/app/src/main/kotlin/compiler/intermediate/generators/SysV64CallingConvention.kt
+++ b/app/src/main/kotlin/compiler/intermediate/generators/SysV64CallingConvention.kt
@@ -7,25 +7,43 @@ import compiler.intermediate.Register
 
 val argPositionToRegister = listOf(Register.RDI, Register.RSI, Register.RDX, Register.RCX, Register.R8, Register.R9)
 val callerSavedRegisters = listOf(Register.RAX, Register.RCX, Register.RDX, Register.RSI, Register.RDI, Register.R8, Register.R9, Register.R10, Register.R11)
+const val stackAlignmentInBytes = 16
 
 object SysV64CallingConvention {
     fun genCall(targetFunction: IFTNode.MemoryLabel, args: List<IFTNode>, returnsValue: Boolean): FunctionDetailsGenerator.FunctionCallIntermediateForm {
-        val cfgBuilder = ControlFlowGraphBuilder()
+        val moveArgsCFGBuilder = ControlFlowGraphBuilder()
         val usedRegisters = mutableListOf<Register>()
 
         // First, move arguments to appropriate registers (or push to stack) according to call convention.
         for ((arg, register) in args zip argPositionToRegister) {
             val node = IFTNode.RegisterWrite(register, arg)
-            cfgBuilder.addLinksFromAllFinalRoots(CFGLinkType.UNCONDITIONAL, node)
+            moveArgsCFGBuilder.addLinksFromAllFinalRoots(CFGLinkType.UNCONDITIONAL, node)
             usedRegisters.add(register)
         }
 
-        var numberOfArgsPushedToStack = 0
+        // Before pushing args stack will be aligned, so code adds links to separate CFGBuilder and merges them later
+        var stackMovement = 0L
         for (arg in args.drop(argPositionToRegister.size).reversed()) {
-            val node = IFTNode.StackPush(arg)
-            cfgBuilder.addLinksFromAllFinalRoots(CFGLinkType.UNCONDITIONAL, node)
-            numberOfArgsPushedToStack += 1
+            moveArgsCFGBuilder.addLinksFromAllFinalRoots(CFGLinkType.UNCONDITIONAL, IFTNode.StackPush(arg))
+            stackMovement += memoryUnitSize.toLong()
         }
+
+        val cfgBuilder = ControlFlowGraphBuilder()
+        // Align stack
+        if (stackMovement % stackAlignmentInBytes != 0L) {
+            val toAdd = stackAlignmentInBytes - stackMovement % stackAlignmentInBytes
+            cfgBuilder.addLinksFromAllFinalRoots(
+                CFGLinkType.UNCONDITIONAL,
+                IFTNode.Subtract(
+                    IFTNode.RegisterRead(Register.RSP),
+                    IFTNode.Const(toAdd)
+                )
+            )
+            stackMovement += toAdd
+        }
+
+        if (moveArgsCFGBuilder.entryTreeRoot != null)
+            cfgBuilder.mergeUnconditionally(moveArgsCFGBuilder.build())
 
         // Add call instruction to actually call a given function
         cfgBuilder.addLinksFromAllFinalRoots(
@@ -34,14 +52,14 @@ object SysV64CallingConvention {
         )
 
         // Abandon arguments that were previously put on stack
-        if (numberOfArgsPushedToStack > 0)
+        if (stackMovement > 0)
             cfgBuilder.addLinksFromAllFinalRoots(
                 CFGLinkType.UNCONDITIONAL,
                 IFTNode.RegisterWrite(
                     Register.RSP,
                     IFTNode.Add(
                         IFTNode.RegisterRead(Register.RSP),
-                        IFTNode.Const(numberOfArgsPushedToStack * memoryUnitSize.toLong())
+                        IFTNode.Const(stackMovement)
                     )
                 )
             )

--- a/app/src/test/kotlin/compiler/intermediate/ConstantTest.kt
+++ b/app/src/test/kotlin/compiler/intermediate/ConstantTest.kt
@@ -5,10 +5,11 @@ import kotlin.test.assertEquals
 
 class ConstantTest {
     @Test
-    fun `test ConstantAlignedToAGivenRestModulo`() {
-        assertEquals(ConstantAlignedToAGivenRestModulo(FixedConstant(23), 10, 3).value, 23)
-        assertEquals(ConstantAlignedToAGivenRestModulo(FixedConstant(23), 10, 5).value, 25)
-        assertEquals(ConstantAlignedToAGivenRestModulo(FixedConstant(23), 10, 0).value, 30)
-        assertEquals(ConstantAlignedToAGivenRestModulo(FixedConstant(23), 10, 2).value, 32)
+    fun `test AlignedConstant`() {
+        assertEquals(AlignedConstant(FixedConstant(23), 10, 3).value, 23)
+        assertEquals(AlignedConstant(FixedConstant(23), 10, 5).value, 25)
+        assertEquals(AlignedConstant(FixedConstant(23), 10, 0).value, 30)
+        assertEquals(AlignedConstant(FixedConstant(23), 10, 2).value, 32)
+        assertEquals(AlignedConstant(FixedConstant(23), 10, -44).value, 26)
     }
 }

--- a/app/src/test/kotlin/compiler/intermediate/ConstantTest.kt
+++ b/app/src/test/kotlin/compiler/intermediate/ConstantTest.kt
@@ -1,0 +1,14 @@
+package compiler.intermediate
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ConstantTest {
+    @Test
+    fun `test ConstantAlignedToAGivenRestModulo`() {
+        assertEquals(ConstantAlignedToAGivenRestModulo(FixedConstant(23), 10, 3).value, 23)
+        assertEquals(ConstantAlignedToAGivenRestModulo(FixedConstant(23), 10, 5).value, 25)
+        assertEquals(ConstantAlignedToAGivenRestModulo(FixedConstant(23), 10, 0).value, 30)
+        assertEquals(ConstantAlignedToAGivenRestModulo(FixedConstant(23), 10, 2).value, 32)
+    }
+}

--- a/app/src/test/kotlin/compiler/intermediate/generators/DefaultFunctionDetailsGeneratorTest.kt
+++ b/app/src/test/kotlin/compiler/intermediate/generators/DefaultFunctionDetailsGeneratorTest.kt
@@ -153,6 +153,70 @@ class DefaultFunctionDetailsGeneratorTest {
     }
 
     @Test
+    fun `test genCall ensures that stack is aligned`() {
+        val params: List<NamedNode> = (0..8).map { Function.Parameter(it.toString(), Type.Number, null) }.toList()
+        val variableToRegisterMap = params.associateWith { Register() } + mapOf(resultDummyVariable to resultVariableRegister)
+        val variablesLocation = params.associateWith { VariableLocationType.REGISTER } + mapOf(resultDummyVariable to VariableLocationType.REGISTER)
+
+        val fdg = DefaultFunctionDetailsGenerator(
+            params,
+            null,
+            functionLocation,
+            0u,
+            variablesLocation,
+            IFTNode.Const(0)
+        ) { variableToRegisterMap[it]!! }
+
+        val args = (0..8).map { IFTNode.Const(it.toLong()) }.toList()
+        val result = fdg.genCall(args)
+
+        val expectedCFGBuilder = ControlFlowGraphBuilder()
+
+        // align stack
+        expectedCFGBuilder.addLinksFromAllFinalRoots(
+            CFGLinkType.UNCONDITIONAL,
+            IFTNode.Subtract(
+                IFTNode.RegisterRead(Register.RSP),
+                IFTNode.Const(8)
+            )
+        )
+
+        // write first 6 args to registers
+        for ((argRegister, arg) in argumentPassingRegisters zip args) {
+            expectedCFGBuilder.addLinksFromAllFinalRoots(
+                CFGLinkType.UNCONDITIONAL,
+                IFTNode.RegisterWrite(argRegister, arg)
+            )
+        }
+
+        // write stack args
+        for (stackArgPos in 8 downTo 6) {
+            expectedCFGBuilder.addLinksFromAllFinalRoots(
+                CFGLinkType.UNCONDITIONAL,
+                IFTNode.StackPush(args[stackArgPos])
+            )
+        }
+
+        // call
+        val callNode = IFTNode.Call(functionLocation, argumentPassingRegisters, callerSavedRegisters)
+        expectedCFGBuilder.addLinksFromAllFinalRoots(CFGLinkType.UNCONDITIONAL, callNode)
+
+        // remove arguments previously put on stack
+        expectedCFGBuilder.addLinksFromAllFinalRoots(
+            CFGLinkType.UNCONDITIONAL,
+            IFTNode.RegisterWrite(
+                Register.RSP,
+                IFTNode.Add(
+                    IFTNode.RegisterRead(Register.RSP),
+                    IFTNode.Const(8 * 4) // 3 args + stack alignment
+                )
+            )
+        )
+        val expected = expectedCFGBuilder.build()
+        assert(expected.equalsByValue(result.callGraph))
+    }
+
+    @Test
     fun `test gen read direct from memory`() {
         val memVar: Variable = Variable(Variable.Kind.VALUE, "memVar", Type.Number, null)
 

--- a/app/src/test/kotlin/compiler/intermediate/generators/DefaultFunctionDetailsGeneratorTest.kt
+++ b/app/src/test/kotlin/compiler/intermediate/generators/DefaultFunctionDetailsGeneratorTest.kt
@@ -175,9 +175,12 @@ class DefaultFunctionDetailsGeneratorTest {
         // align stack
         expectedCFGBuilder.addLinksFromAllFinalRoots(
             CFGLinkType.UNCONDITIONAL,
-            IFTNode.Subtract(
-                IFTNode.RegisterRead(Register.RSP),
-                IFTNode.Const(8)
+            IFTNode.RegisterWrite(
+                Register.RSP,
+                IFTNode.Subtract(
+                    IFTNode.RegisterRead(Register.RSP),
+                    IFTNode.Const(8)
+                )
             )
         )
 


### PR DESCRIPTION
We're using stack pointer modifying instructions (add directly to `RSP`, `StackPush`, `StackPop` and `Call`) only in `genPrologue, genEpilogue` and `genCall` functions. 
The stack will be alligned to 16 bytes at the entry of each program, so all we have to do is to:
1) move RSP by 8 bytes at thebeginning of `genCall` if some function has more than an odd, larger than 6 number of arguments
2) make sure allocated space for non-local and spilled variables in `genPrologue` is divisible by 16.