### PR TITLE
Compiler integration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,6 +26,8 @@ configurations {
 }
 
 dependencies {
+    implementation("com.github.ajalt.clikt:clikt:3.5.0")
+
     // Align versions of all Kotlin components
     implementation platform('org.jetbrains.kotlin:kotlin-bom')
 

--- a/app/src/main/kotlin/compiler/App.kt
+++ b/app/src/main/kotlin/compiler/App.kt
@@ -1,6 +1,24 @@
 package compiler
 
+import compiler.diagnostics.CompilerDiagnostics
+import java.io.PrintWriter
+import java.io.StringReader
+import java.io.StringWriter
+
 fun main() {
+    val diagnostics = CompilerDiagnostics()
+    val compiler = Compiler(diagnostics)
+
+    val program = """
+        czynność główna() {
+            zm n : Liczba = 3
+            n = n + 1
+        }
+    """
+    val reader = StringReader(program)
+    val writer = PrintWriter(StringWriter())
+
+    compiler.process(reader, writer)
     // TODO:
     // - create Reader for input source file
     // - create Writer for output assembly file

--- a/app/src/main/kotlin/compiler/App.kt
+++ b/app/src/main/kotlin/compiler/App.kt
@@ -7,49 +7,48 @@ import com.github.ajalt.clikt.parameters.options.option
 import compiler.diagnostics.CompilerDiagnostics
 import java.io.File
 import java.io.FileNotFoundException
-import java.io.FileReader
-import java.io.PrintWriter
+import kotlin.system.exitProcess
 
 fun runCommand(command: String) {
     println(command)
-    ProcessBuilder(*command.split(" ").toTypedArray())
+    val process = ProcessBuilder(*command.split(" ").toTypedArray())
         .redirectOutput(ProcessBuilder.Redirect.INHERIT)
         .redirectError(ProcessBuilder.Redirect.INHERIT)
         .start()
+    process.waitFor()
+    if (process.exitValue() != 0) {
+        exitProcess(process.exitValue())
+    }
 }
 
 class Cli : CliktCommand() {
-    val inputFile: String by argument("input file", help = "Input file")
-    val externFile: String? by option("-e", "--extern", help = "Extern file")
-    val assemblyFile: String by option("-a", "--assembly", help = "Assembly file").default("a.asm")
-    val listingFile: String? by option("-l", "--listing", help = "Listing file")
-    val objectFile: String by option("-b", "--object", help = "Object file").default("a.o")
-    val outputFile: String by option("-o", "--output", help = "Output file").default("a.out")
+    private val inputFile: String by argument("input file", help = "Input file")
+    private val stdlibLocation: String by option("-l", "--stdlib", help = "Standard library location").default("stdlib.o")
+    private val assemblyFile: String by option("-a", "--assembly", help = "Assembly file").default("a.asm")
+    private val objectFile: String by option("-b", "--object", help = "Object file").default("a.o")
+    private val outputFile: String by option("-o", "--output", help = "Output file").default("a.out")
 
     override fun run() {
         val diagnostics = CompilerDiagnostics()
         val compiler = Compiler(diagnostics)
 
         try {
-            val reader = FileReader(File(inputFile))
-
-            val writer = PrintWriter(File(assemblyFile))
-
-            if (!compiler.process(reader, PrintWriter(writer))) {
-                println("Compilation failed")
-                diagnostics.diagnostics.forEach { println(it) }
-                return
+            File(inputFile).reader().use { input ->
+                File(assemblyFile).writer().use { output ->
+                    if (!compiler.process(input, output)) {
+                        println("Compilation failed")
+                        diagnostics.diagnostics.forEach { println(it) }
+                        exitProcess(1)
+                    }
+                }
             }
-
-            writer.close()
-            reader.close()
         } catch (err: FileNotFoundException) {
-            println("Error: ${err.message}")
-            return
+            println("File error: ${err.message}")
+            exitProcess(1)
         }
 
-        runCommand("nasm -f elf64 $assemblyFile${listingFile?.let { " -l $it" } ?: ""} -o $objectFile")
-        runCommand("gcc -static $objectFile${externFile?.let {" $it"} ?: ""} -o $outputFile")
+        runCommand("nasm -f elf64 $assemblyFile -o $objectFile")
+        runCommand("gcc -static $objectFile $stdlibLocation -o $outputFile")
     }
 }
 

--- a/app/src/main/kotlin/compiler/App.kt
+++ b/app/src/main/kotlin/compiler/App.kt
@@ -1,29 +1,56 @@
 package compiler
 
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
 import compiler.diagnostics.CompilerDiagnostics
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.FileReader
 import java.io.PrintWriter
-import java.io.StringReader
-import java.io.StringWriter
 
-fun main() {
-    val diagnostics = CompilerDiagnostics()
-    val compiler = Compiler(diagnostics)
-
-    val program = """
-        czynność główna() {
-            zm n : Liczba = 3
-            n = n + 1
-        }
-    """
-    val reader = StringReader(program)
-    val writer = PrintWriter(StringWriter())
-
-    compiler.process(reader, writer)
-    // TODO:
-    // - create Reader for input source file
-    // - create Writer for output assembly file
-    // - call Compiler.process()
-    // - report any diagnostics
-    // - execute NASM on output assembly file
-    // - execute GCC or LD on resulting object file
+fun runCommand(command: String) {
+    println(command)
+    ProcessBuilder(*command.split(" ").toTypedArray())
+        .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        .redirectError(ProcessBuilder.Redirect.INHERIT)
+        .start()
 }
+
+class Cli : CliktCommand() {
+    val inputFile: String by argument("input file", help = "Input file")
+    val externFile: String? by option("-e", "--extern", help = "Extern file")
+    val assemblyFile: String by option("-a", "--assembly", help = "Assembly file").default("a.asm")
+    val listingFile: String? by option("-l", "--listing", help = "Listing file")
+    val objectFile: String by option("-b", "--object", help = "Object file").default("a.o")
+    val outputFile: String by option("-o", "--output", help = "Output file").default("a.out")
+
+    override fun run() {
+        val diagnostics = CompilerDiagnostics()
+        val compiler = Compiler(diagnostics)
+
+        try {
+            val reader = FileReader(File(inputFile))
+
+            val writer = PrintWriter(File(assemblyFile))
+
+            if (!compiler.process(reader, PrintWriter(writer))) {
+                println("Compilation failed")
+                diagnostics.diagnostics.forEach { println(it) }
+                return
+            }
+
+            writer.close()
+            reader.close()
+        } catch (err: FileNotFoundException) {
+            println("Error: ${err.message}")
+            return
+        }
+
+        runCommand("nasm -f elf64 $assemblyFile${listingFile?.let { " -l $it" } ?: ""} -o $objectFile")
+        runCommand("gcc -static $objectFile${externFile?.let {" $it"} ?: ""} -o $outputFile")
+    }
+}
+
+fun main(args: Array<String>) = Cli().main(args)

--- a/app/src/main/kotlin/compiler/Compiler.kt
+++ b/app/src/main/kotlin/compiler/Compiler.kt
@@ -120,13 +120,6 @@ class Compiler(val diagnostics: Diagnostics) {
                 output.println()
             }
 
-            // TODO:
-            // - make sure "główna" is present and generate a jump to it from "main",
-            // - linearize CFG for each function,
-            // - run liveness analysis on each linear function code,
-            // - run register allocation on each linear function code,
-            // - write ASM to output (display, global variables, functions)
-
             return true
         } catch (_: CompilationFailed) { }
 

--- a/app/src/main/kotlin/compiler/Compiler.kt
+++ b/app/src/main/kotlin/compiler/Compiler.kt
@@ -2,12 +2,15 @@ package compiler
 
 import compiler.analysis.BuiltinFunctions
 import compiler.analysis.ProgramAnalyzer
+import compiler.ast.Function
 import compiler.ast.Program
 import compiler.diagnostics.Diagnostic
 import compiler.diagnostics.Diagnostics
 import compiler.input.ReaderInput
 import compiler.intermediate.ControlFlow.createGraphForProgram
+import compiler.intermediate.FunctionDependenciesAnalyzer
 import compiler.lexer.Lexer
+import compiler.lowlevel.Instruction
 import compiler.lowlevel.allocation.Allocation
 import compiler.lowlevel.allocation.ColoringAllocation
 import compiler.lowlevel.dataflow.Liveness
@@ -51,22 +54,26 @@ class Compiler(val diagnostics: Diagnostics) {
 
             val programProperties = ProgramAnalyzer.analyzeProgram(astWithBuiltinFunctions, diagnostics)
 
-            val functionCFGs = createGraphForProgram(astWithBuiltinFunctions, programProperties, diagnostics, diagnostics.hasAnyError())
+            val functionDetailsGenerators = FunctionDependenciesAnalyzer.createFunctionDetailsGenerators(
+                astWithBuiltinFunctions,
+                programProperties.variableProperties,
+                programProperties.functionReturnedValueVariables,
+                diagnostics.hasAnyError()
+            )
 
-            if (!ast.globals.any { it is Program.Global.FunctionDefinition && it.function.name == "główna" }) {
+            val functionCFGs = createGraphForProgram(astWithBuiltinFunctions, programProperties, functionDetailsGenerators, diagnostics)
+
+            val mainFunction = (
+                ast.globals.find { it is Program.Global.FunctionDefinition && it.function.name == "główna" } as Program.Global.FunctionDefinition?
+                )?.function
+            if (mainFunction == null) {
                 diagnostics.report(Diagnostic.MainFunctionNotFound())
             }
 
             if (diagnostics.hasAnyError())
                 return false
 
-            val linearFunctions = functionCFGs.mapValues { Linearization.linearize(it.value.cfg, covering) }
-
-//            for ((function, instructions) in linearFunctions.entries) {
-//                println(function)
-//                for (instruction in instructions) println(instruction)
-//                println()
-//            }
+            val linearFunctions = functionCFGs.mapValues { Linearization.linearize(it.value, covering) }
 
             val finalCode = linearFunctions.mapValues {
                 Allocation.allocateRegistersWithSpillsHandling(
@@ -77,18 +84,39 @@ class Compiler(val diagnostics: Diagnostics) {
                 )
             }
 
-            finalCode.entries.forEach { functionCFGs[it.key]!!.offset.settledValue = it.value.spilledOffset.toLong() }
+            finalCode.entries.forEach { functionDetailsGenerators[it.key]!!.spilledRegistersOffset.settledValue = it.value.spilledOffset.toLong() }
 
-            output.println("section .bss")
+            output.println("SECTION .bss")
             DisplayStorage(programProperties.staticDepth).writeAsm(output)
-            output.println("\nsection .data")
+
+            output.println("\nSECTION .data")
             GlobalVariableStorage(ast).writeAsm(output)
 
-            output.println("\nsection .text")
-            finalCode.forEach { function ->
-                function.value.linearProgram.forEach {
-                    it.writeAsm(output, function.value.allocatedRegisters)
-                }
+            output.println("\nSECTION .text")
+            functionDetailsGenerators
+                .filter { it.key.implementation is Function.Implementation.Foreign }
+                .forEach { output.println("extern ${it.value.identifier}") }
+            output.println(
+                """
+                    global main
+                    main:
+                        call ${functionDetailsGenerators[mainFunction]!!.identifier}
+                        
+                """.trimIndent()
+            )
+
+            finalCode.forEach { functionCode ->
+                output.println("${functionDetailsGenerators[functionCode.key]!!.identifier}:")
+                functionCode.value.linearProgram
+                    .filterNot {
+                        it is Instruction.InPlaceInstruction.MoveRR &&
+                            functionCode.value.allocatedRegisters[it.reg_dest] == functionCode.value.allocatedRegisters[it.reg_src]
+                    }
+                    .forEach {
+                        output.print("    ")
+                        it.writeAsm(output, functionCode.value.allocatedRegisters)
+                        output.println()
+                    }
                 output.println()
             }
 

--- a/app/src/main/kotlin/compiler/Compiler.kt
+++ b/app/src/main/kotlin/compiler/Compiler.kt
@@ -101,7 +101,8 @@ class Compiler(val diagnostics: Diagnostics) {
                     global main
                     main:
                         call ${functionDetailsGenerators[mainFunction]!!.identifier}
-                        
+                        ret
+                    
                 """.trimIndent()
             )
 

--- a/app/src/main/kotlin/compiler/Compiler.kt
+++ b/app/src/main/kotlin/compiler/Compiler.kt
@@ -3,14 +3,14 @@ package compiler
 import compiler.analysis.BuiltinFunctions
 import compiler.analysis.ProgramAnalyzer
 import compiler.ast.Function
-import compiler.ast.Program
-import compiler.diagnostics.Diagnostic
+import compiler.ast.Type
 import compiler.diagnostics.Diagnostics
 import compiler.input.ReaderInput
 import compiler.intermediate.ControlFlow.createGraphForProgram
 import compiler.intermediate.FunctionDependenciesAnalyzer
 import compiler.lexer.Lexer
-import compiler.lowlevel.Instruction
+import compiler.lowlevel.AsmFile
+import compiler.lowlevel.CodeSection
 import compiler.lowlevel.allocation.Allocation
 import compiler.lowlevel.allocation.ColoringAllocation
 import compiler.lowlevel.dataflow.Liveness
@@ -28,6 +28,7 @@ import compiler.syntax.Symbol
 import compiler.syntax.TokenType
 import java.io.PrintWriter
 import java.io.Reader
+import java.io.Writer
 
 // The main class used to compile a source code into an executable machine code.
 class Compiler(val diagnostics: Diagnostics) {
@@ -39,7 +40,7 @@ class Compiler(val diagnostics: Diagnostics) {
     private val parser = Parser(LanguageGrammar.getGrammar(), diagnostics)
     private val covering = DynamicCoveringBuilder(InstructionSet.getInstructionSet())
 
-    fun process(input: Reader, output: PrintWriter): Boolean {
+    fun process(input: Reader, output: Writer): Boolean {
         try {
             val tokenSequence = lexer.process(ReaderInput(input))
 
@@ -63,12 +64,7 @@ class Compiler(val diagnostics: Diagnostics) {
 
             val functionCFGs = createGraphForProgram(astWithBuiltinFunctions, programProperties, functionDetailsGenerators, diagnostics)
 
-            val mainFunction = (
-                ast.globals.find { it is Program.Global.FunctionDefinition && it.function.name == "główna" } as Program.Global.FunctionDefinition?
-                )?.function
-            if (mainFunction == null) {
-                diagnostics.report(Diagnostic.MainFunctionNotFound())
-            }
+            val mainFunction = FunctionDependenciesAnalyzer.extractMainFunction(ast, diagnostics)
 
             if (diagnostics.hasAnyError())
                 return false
@@ -86,40 +82,25 @@ class Compiler(val diagnostics: Diagnostics) {
 
             finalCode.entries.forEach { functionDetailsGenerators[it.key]!!.spilledRegistersOffset.settledValue = it.value.spilledOffset.toLong() }
 
-            output.println("SECTION .bss")
-            DisplayStorage(programProperties.staticDepth).writeAsm(output)
-
-            output.println("\nSECTION .data")
-            GlobalVariableStorage(ast).writeAsm(output)
-
-            output.println("\nSECTION .text")
-            functionDetailsGenerators
-                .filter { it.key.implementation is Function.Implementation.Foreign }
-                .forEach { output.println("extern ${it.value.identifier}") }
-            output.println(
-                """
-                    global main
-                    main:
-                        call ${functionDetailsGenerators[mainFunction]!!.identifier}
-                        ret
-                    
-                """.trimIndent()
+            AsmFile.printFile(
+                PrintWriter(output),
+                DisplayStorage(programProperties.staticDepth)::writeAsm,
+                GlobalVariableStorage(ast)::writeAsm,
+                CodeSection(
+                    functionDetailsGenerators[mainFunction]!!.identifier,
+                    mainFunction!!.returnType != Type.Number,
+                    functionDetailsGenerators
+                        .filter { it.key.implementation is Function.Implementation.Foreign }
+                        .map { it.value.identifier },
+                    finalCode.map { functionCode ->
+                        functionDetailsGenerators[functionCode.key]!!.identifier to
+                            CodeSection.FunctionCode(
+                                functionCode.value.linearProgram,
+                                functionCode.value.allocatedRegisters
+                            )
+                    }.toMap()
+                )::writeAsm
             )
-
-            finalCode.forEach { functionCode ->
-                output.println("${functionDetailsGenerators[functionCode.key]!!.identifier}:")
-                functionCode.value.linearProgram
-                    .filterNot {
-                        it is Instruction.InPlaceInstruction.MoveRR &&
-                            functionCode.value.allocatedRegisters[it.reg_dest] == functionCode.value.allocatedRegisters[it.reg_src]
-                    }
-                    .forEach {
-                        output.print("    ")
-                        it.writeAsm(output, functionCode.value.allocatedRegisters)
-                        output.println()
-                    }
-                output.println()
-            }
 
             return true
         } catch (_: CompilationFailed) { }

--- a/app/src/main/kotlin/compiler/diagnostics/Diagnostic.kt
+++ b/app/src/main/kotlin/compiler/diagnostics/Diagnostic.kt
@@ -56,6 +56,11 @@ sealed interface Diagnostic {
         }
     }
 
+    class MainFunctionNotFound() : Diagnostic {
+        override fun isError(): Boolean = true
+        override fun toString(): String = "Main function 'główna' not found"
+    }
+
     sealed class ResolutionDiagnostic(astNodes: List<AstNode>) : Diagnostic {
 
         data class ObjectAssociatedToError(val message: String, val location: LocationRange?)

--- a/app/src/main/kotlin/compiler/intermediate/ControlFlowGraph.kt
+++ b/app/src/main/kotlin/compiler/intermediate/ControlFlowGraph.kt
@@ -1,9 +1,10 @@
 package compiler.intermediate
 
 import compiler.utils.ReferenceMap
+import compiler.utils.ReferenceSet
 
 data class ControlFlowGraph(
-    val treeRoots: List<IFTNode>,
+    val treeRoots: ReferenceSet<IFTNode>,
     val entryTreeRoot: IFTNode?,
     val unconditionalLinks: ReferenceMap<IFTNode, IFTNode>,
     val conditionalTrueLinks: ReferenceMap<IFTNode, IFTNode>,

--- a/app/src/main/kotlin/compiler/intermediate/ControlFlowGraphBuilder.kt
+++ b/app/src/main/kotlin/compiler/intermediate/ControlFlowGraphBuilder.kt
@@ -1,6 +1,7 @@
 package compiler.intermediate
 
 import compiler.utils.referenceHashMapOf
+import compiler.utils.referenceHashSetOf
 
 class IncorrectControlFlowGraphError(message: String) : Exception(message)
 
@@ -8,7 +9,7 @@ class ControlFlowGraphBuilder(@JvmField var entryTreeRoot: IFTNode? = null) {
     private var unconditionalLinks = referenceHashMapOf<IFTNode, IFTNode>()
     private var conditionalTrueLinks = referenceHashMapOf<IFTNode, IFTNode>()
     private var conditionalFalseLinks = referenceHashMapOf<IFTNode, IFTNode>()
-    private var treeRoots = ArrayList<IFTNode>()
+    private var treeRoots = referenceHashSetOf<IFTNode>()
 
     init {
         entryTreeRoot?.let { treeRoots.add(it) }
@@ -89,7 +90,7 @@ class ControlFlowGraphBuilder(@JvmField var entryTreeRoot: IFTNode? = null) {
     fun addSingleTree(iftNode: IFTNode): ControlFlowGraphBuilder {
         mergeUnconditionally(
             ControlFlowGraph(
-                listOf(iftNode),
+                referenceHashSetOf(iftNode),
                 iftNode, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf()
             )
         )

--- a/app/src/main/kotlin/compiler/intermediate/FunctionDependenciesAnalyzer.kt
+++ b/app/src/main/kotlin/compiler/intermediate/FunctionDependenciesAnalyzer.kt
@@ -9,6 +9,8 @@ import compiler.ast.Statement
 import compiler.ast.StatementBlock
 import compiler.ast.Type
 import compiler.ast.Variable
+import compiler.diagnostics.Diagnostic
+import compiler.diagnostics.Diagnostics
 import compiler.intermediate.generators.DISPLAY_LABEL_IN_MEMORY
 import compiler.intermediate.generators.DefaultFunctionDetailsGenerator
 import compiler.intermediate.generators.ForeignFunctionDetailsGenerator
@@ -69,6 +71,18 @@ object FunctionDependenciesAnalyzer {
         }
         program.globals.forEach { analyze(it) }
         return uniqueIdentifiers
+    }
+
+    fun extractMainFunction(program: Program, diagnostics: Diagnostics): Function? {
+        val mainFunction = (
+            program.globals.find {
+                it is Program.Global.FunctionDefinition && it.function.name == MAIN_FUNCTION_IDENTIFIER
+            } as Program.Global.FunctionDefinition?
+            )?.function
+        if (mainFunction == null) {
+            diagnostics.report(Diagnostic.MainFunctionNotFound())
+        }
+        return mainFunction
     }
 
     fun createFunctionDetailsGenerators(

--- a/app/src/main/kotlin/compiler/intermediate/Register.kt
+++ b/app/src/main/kotlin/compiler/intermediate/Register.kt
@@ -62,4 +62,12 @@ class Register {
         R15 -> "r15b"
         else -> throw VirtualRegisterIsNotAsmable()
     }
+
+    override fun toString(): String {
+        return try {
+            toAsm()
+        } catch (err: VirtualRegisterIsNotAsmable) {
+            super.toString()
+        }
+    }
 }

--- a/app/src/main/kotlin/compiler/intermediate/UniqueIdentifier.kt
+++ b/app/src/main/kotlin/compiler/intermediate/UniqueIdentifier.kt
@@ -6,6 +6,8 @@ import compiler.intermediate.generators.GlobalVariableAccessGenerator
 class IllegalCharacter(message: String) : RuntimeException(message)
 class InconsistentFunctionNamingConvention(message: String) : RuntimeException(message)
 
+const val MAIN_FUNCTION_IDENTIFIER = "główna"
+
 class UniqueIdentifierFactory() {
     companion object {
         // it might be handy to change these values with ease

--- a/app/src/main/kotlin/compiler/intermediate/generators/DefaultFunctionDetailsGenerator.kt
+++ b/app/src/main/kotlin/compiler/intermediate/generators/DefaultFunctionDetailsGenerator.kt
@@ -38,7 +38,7 @@ data class DefaultFunctionDetailsGenerator(
     private val calleeSavedBackupRegisters = calleeSavedRegistersWithoutRSPAndRBP.map { Register() }
 
     override val spilledRegistersOffset: ConstantPlaceholder = ConstantPlaceholder()
-
+    override val identifier: String = functionLocationInCode.label
     init {
         for ((variable, locationType) in variablesLocationTypes.entries) {
             when (locationType) {

--- a/app/src/main/kotlin/compiler/intermediate/generators/ForeignFunctionDetailsGenerator.kt
+++ b/app/src/main/kotlin/compiler/intermediate/generators/ForeignFunctionDetailsGenerator.kt
@@ -17,6 +17,8 @@ class ForeignFunctionDetailsGenerator(
 
     override val spilledRegistersOffset get() = throw NotImplementedError()
 
+    override val identifier: String = memoryLabel.label
+
     override fun genRead(namedNode: NamedNode, isDirect: Boolean) = throw NotImplementedError()
 
     override fun genWrite(namedNode: NamedNode, value: IFTNode, isDirect: Boolean) = throw NotImplementedError()

--- a/app/src/main/kotlin/compiler/intermediate/generators/FunctionDetailsGenerator.kt
+++ b/app/src/main/kotlin/compiler/intermediate/generators/FunctionDetailsGenerator.kt
@@ -17,4 +17,6 @@ interface FunctionDetailsGenerator : VariableAccessGenerator {
     fun genEpilogue(): ControlFlowGraph
 
     val spilledRegistersOffset: ConstantPlaceholder
+
+    val identifier: String
 }

--- a/app/src/main/kotlin/compiler/lowlevel/AsmFile.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/AsmFile.kt
@@ -11,6 +11,7 @@ object AsmFile {
     ) {
         output.println("SECTION .bss")
         bssSection(output)
+        output.println()
 
         output.println("SECTION .data")
         dataSection(output)

--- a/app/src/main/kotlin/compiler/lowlevel/AsmFile.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/AsmFile.kt
@@ -1,0 +1,22 @@
+package compiler.lowlevel
+
+import java.io.PrintWriter
+
+object AsmFile {
+    fun printFile(
+        output: PrintWriter,
+        bssSection: (PrintWriter) -> Unit,
+        dataSection: (PrintWriter) -> Unit,
+        textSection: (PrintWriter) -> Unit
+    ) {
+        output.println("SECTION .bss")
+        bssSection(output)
+
+        output.println("SECTION .data")
+        dataSection(output)
+        output.println()
+
+        output.println("SECTION .text")
+        textSection(output)
+    }
+}

--- a/app/src/main/kotlin/compiler/lowlevel/CodeSection.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/CodeSection.kt
@@ -18,10 +18,11 @@ class CodeSection(
             """
                 global main
                 main:
-                    mov rbp, rsp
                     push rbp
+                    mov rbp, rsp
                     call $mainFunctionLabel
                     ${if (ignoreMainReturnValue) "xor rax, rax" else "" }
+                    mov rsp, rbp
                     pop rbp
                     ret
                 

--- a/app/src/main/kotlin/compiler/lowlevel/CodeSection.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/CodeSection.kt
@@ -1,0 +1,41 @@
+package compiler.lowlevel
+
+import compiler.intermediate.Register
+import java.io.PrintWriter
+
+class CodeSection(
+    val mainFunctionLabel: String,
+    val ignoreMainReturnValue: Boolean,
+    val foreignFunctionIdentifiers: List<String>,
+    val functions: Map<String, FunctionCode>
+) {
+    data class FunctionCode(val instructions: List<Asmable>, val registerAllocation: Map<Register, Register>)
+
+    fun writeAsm(output: PrintWriter) {
+        foreignFunctionIdentifiers.forEach { output.println("extern $it") }
+
+        output.println(
+            """
+                global main
+                main:
+                    mov rbp, rsp
+                    push rbp
+                    call $mainFunctionLabel
+                    ${if (ignoreMainReturnValue) "xor rax, rax" else "" }
+                    pop rbp
+                    ret
+                
+            """.trimIndent()
+        )
+
+        functions.forEach { function ->
+            output.println("${function.key}:")
+            function.value.instructions.forEach {
+                output.print("    ")
+                it.writeAsm(output, function.value.registerAllocation)
+                output.println()
+            }
+            output.println()
+        }
+    }
+}

--- a/app/src/main/kotlin/compiler/lowlevel/CodeSection.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/CodeSection.kt
@@ -22,7 +22,6 @@ class CodeSection(
                     mov rbp, rsp
                     call $mainFunctionLabel
                     ${if (ignoreMainReturnValue) "xor rax, rax" else "" }
-                    mov rsp, rbp
                     pop rbp
                     ret
                 

--- a/app/src/main/kotlin/compiler/lowlevel/Label.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/Label.kt
@@ -4,5 +4,5 @@ import compiler.intermediate.Register
 import java.io.PrintWriter
 
 data class Label(val label: String) : Asmable {
-    override fun writeAsm(output: PrintWriter, registers: Map<Register, Register>) = output.write(".$label:")
+    override fun writeAsm(output: PrintWriter, registers: Map<Register, Register>) = output.write("$label:")
 }

--- a/app/src/main/kotlin/compiler/lowlevel/allocation/Allocation.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/allocation/Allocation.kt
@@ -17,6 +17,8 @@ object Allocation {
         Register.R12,
         Register.R11,
         Register.R10,
+        Register.RBP,
+        Register.RSP,
         Register.R9,
         Register.R8,
         Register.RDI,
@@ -25,8 +27,6 @@ object Allocation {
         Register.RCX,
         Register.RBX,
         Register.RAX,
-        Register.RBP,
-        Register.RSP,
     )
 
     data class Result(
@@ -42,7 +42,6 @@ object Allocation {
         orderedPhysicalRegisters: List<Register>,
         allocator: PartialAllocation
     ): Result {
-        linearProgram.forEach { println(it) }
         var reservedRegistersNumber = 0
         while (true) {
             val availableRegisters = orderedPhysicalRegisters.drop(reservedRegistersNumber)

--- a/app/src/main/kotlin/compiler/lowlevel/allocation/Allocation.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/allocation/Allocation.kt
@@ -42,6 +42,7 @@ object Allocation {
         orderedPhysicalRegisters: List<Register>,
         allocator: PartialAllocation
     ): Result {
+        linearProgram.forEach { println(it) }
         var reservedRegistersNumber = 0
         while (true) {
             val availableRegisters = orderedPhysicalRegisters.drop(reservedRegistersNumber)

--- a/app/src/main/kotlin/compiler/lowlevel/allocation/Allocation.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/allocation/Allocation.kt
@@ -11,14 +11,8 @@ import compiler.lowlevel.dataflow.Liveness
 object Allocation {
 
     val REGISTER_ORDER = listOf(
-        Register.R15,
-        Register.R14,
-        Register.R13,
-        Register.R12,
         Register.R11,
         Register.R10,
-        Register.RBP,
-        Register.RSP,
         Register.R9,
         Register.R8,
         Register.RDI,
@@ -27,6 +21,12 @@ object Allocation {
         Register.RCX,
         Register.RBX,
         Register.RAX,
+        Register.R15,
+        Register.R14,
+        Register.R13,
+        Register.R12,
+        Register.RBP,
+        Register.RSP,
     )
 
     data class Result(
@@ -72,7 +72,10 @@ object Allocation {
                     instructionsToSpilled,
                     registerAllocation,
                     spilledRegistersColoring,
-                )
+                ).filterNot {
+                    it is Instruction.InPlaceInstruction.MoveRR &&
+                        registerAllocation[it.reg_dest] == registerAllocation[it.reg_src]
+                }
 
                 return Result(
                     registerAllocation,

--- a/app/src/main/kotlin/compiler/lowlevel/allocation/Allocation.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/allocation/Allocation.kt
@@ -10,6 +10,25 @@ import compiler.lowlevel.dataflow.Liveness
 
 object Allocation {
 
+    val REGISTER_ORDER = listOf(
+        Register.R15,
+        Register.R14,
+        Register.R13,
+        Register.R12,
+        Register.R11,
+        Register.R10,
+        Register.R9,
+        Register.R8,
+        Register.RDI,
+        Register.RSI,
+        Register.RDX,
+        Register.RCX,
+        Register.RBX,
+        Register.RAX,
+        Register.RBP,
+        Register.RSP,
+    )
+
     data class Result(
         val allocatedRegisters: Map<Register, Register>,
         val linearProgram: List<Asmable>,

--- a/app/src/main/kotlin/compiler/lowlevel/dataflow/DataFlowAnalyzer.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/dataflow/DataFlowAnalyzer.kt
@@ -31,7 +31,6 @@ abstract class DataFlowAnalyzer<SL> {
                     when (it) {
                         is Label -> labelToInstruction[it.label]!!
                         is Instruction -> it
-//                        else -> Instruction.InPlaceInstruction.Dummy()
                     }
                 }
 
@@ -42,8 +41,6 @@ abstract class DataFlowAnalyzer<SL> {
             if (backward) predecessors[from]!!.add(to)
             else predecessors[to]!!.add(from)
         }
-
-//        linearProgram.forEach { println(it) }
 
         instructionList.forEachIndexed { index, it ->
             when (it) {

--- a/app/src/main/kotlin/compiler/lowlevel/dataflow/DataFlowAnalyzer.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/dataflow/DataFlowAnalyzer.kt
@@ -31,6 +31,7 @@ abstract class DataFlowAnalyzer<SL> {
                     when (it) {
                         is Label -> labelToInstruction[it.label]!!
                         is Instruction -> it
+//                        else -> Instruction.InPlaceInstruction.Dummy()
                     }
                 }
 
@@ -41,6 +42,8 @@ abstract class DataFlowAnalyzer<SL> {
             if (backward) predecessors[from]!!.add(to)
             else predecessors[to]!!.add(from)
         }
+
+//        linearProgram.forEach { println(it) }
 
         instructionList.forEachIndexed { index, it ->
             when (it) {

--- a/app/src/main/kotlin/compiler/lowlevel/linearization/DynamicCoveringBuilder.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/linearization/DynamicCoveringBuilder.kt
@@ -10,7 +10,7 @@ typealias PatternChoices = ReferenceHashMap<IFTNode, Pattern>
 val matchValue: (Pattern, IFTNode) -> Pattern.Result? = { pattern, iftnode -> pattern.matchValue(iftnode) }
 
 // Assumes that every possible IFTNode has at least one viable covering with the passed instruction set
-class DynamicCoveringBuilder(private val instructionSet: InstructionSet) : Covering {
+class DynamicCoveringBuilder(private val instructionSet: List<Pattern>) : Covering {
     private fun getBestPatterns(
         topPatternMatcher: (Pattern, IFTNode) -> Pattern.Result?,
         parent: IFTNode
@@ -33,7 +33,7 @@ class DynamicCoveringBuilder(private val instructionSet: InstructionSet) : Cover
                 if (matchedPattern == null) return null
                 return matchedPattern.subtrees.sumOf { calculateBestPatternAndCost(it) } + matchedPattern.cost
             }
-            val possiblePatternsToCosts = instructionSet.getInstructionSet().associateWith(::calculateCostForPattern)
+            val possiblePatternsToCosts = instructionSet.associateWith(::calculateCostForPattern)
                 .filter { it.value != null }
             minimalCosts[iftNode] = possiblePatternsToCosts.maxOf { it.value as Int }
             bestPatterns[iftNode] = possiblePatternsToCosts.minByOrNull { it.value!! }!!.key

--- a/app/src/main/kotlin/compiler/lowlevel/linearization/InstructionSet.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/linearization/InstructionSet.kt
@@ -73,6 +73,22 @@ object InstructionSet {
                 _, outRegister, _, args ->
                 listOf(Instruction.InPlaceInstruction.MoveRI(outRegister, args["const"] as Constant)) // MOV  out,  const
             },
+            InstructionPattern(
+                IFTPattern.MemoryWrite(
+                    IFTPattern.BinaryOperator(
+                        IFTNode.Add::class,
+                        IFTPattern.MemoryLabel(IFTPattern.AnyArgument("label"))
+                    ),
+                )
+            ) {
+                inRegisters, _, _, args ->
+                listOf(
+                    Instruction.InPlaceInstruction.MoveMR(
+                        Addressing.Base(inRegisters[0], Addressing.MemoryAddress.Label(args["label"] as String)),
+                        inRegisters[1]
+                    )
+                ) // MOV  [label + reg0], reg1
+            },
             InstructionPattern(IFTPattern.MemoryWrite()) {
                 inRegisters, _, _, _ ->
                 listOf(Instruction.InPlaceInstruction.MoveMR(Addressing.Base(inRegisters[0]), inRegisters[1])) // MOV  [reg0], reg1
@@ -130,7 +146,11 @@ object InstructionSet {
             ) {
                 _, _, _, args ->
                 listOf(
-                    Instruction.InPlaceInstruction.CallL(args["label"] as String, args["usedRegs"] as Collection<Register>, args["definedRegs"] as Collection<Register>) // CALL label
+                    Instruction.InPlaceInstruction.CallL(
+                        args["label"] as String,
+                        args["usedRegs"] as Collection<Register>,
+                        args["definedRegs"] as Collection<Register>
+                    ) // CALL label
                 )
             },
             InstructionPattern(
@@ -142,7 +162,11 @@ object InstructionSet {
             ) {
                 inRegisters, _, _, args ->
                 listOf(
-                    Instruction.InPlaceInstruction.CallR(inRegisters[0], args["usedRegs"] as Collection<Register> + setOf(inRegisters[0]), args["definedRegs"] as Collection<Register>) // CALL reg0
+                    Instruction.InPlaceInstruction.CallR(
+                        inRegisters[0],
+                        args["usedRegs"] as Collection<Register> + setOf(inRegisters[0]),
+                        args["definedRegs"] as Collection<Register> + setOf(Register.RSP)
+                    ) // CALL reg0
                 )
             },
             InstructionPattern(IFTPattern.Return(IFTPattern.AnyArgument("usedRegs"))) {

--- a/app/src/main/kotlin/compiler/lowlevel/linearization/InstructionSet.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/linearization/InstructionSet.kt
@@ -86,9 +86,28 @@ object InstructionSet {
                 _, _, _, args ->
                 listOf(Instruction.InPlaceInstruction.MoveRI(args["reg"] as Register, args["const"] as Constant)) // MOV  reg,  const
             },
+            InstructionPattern(
+                IFTPattern.RegisterWrite(
+                    IFTPattern.AnyArgument("reg_dest"),
+                    IFTPattern.RegisterRead(IFTPattern.AnyArgument("reg_src"))
+                )
+            ) {
+                _, _, _, args ->
+                listOf(Instruction.InPlaceInstruction.MoveRR(args["reg_dest"] as Register, args["reg_src"] as Register)) // MOV  reg_dest,  reg_src
+            },
+            InstructionPattern(IFTPattern.RegisterWrite(IFTPattern.AnyArgument("reg"), IFTPattern.StackPop())) {
+                _, _, _, args ->
+                listOf(Instruction.InPlaceInstruction.PopR(args["reg"] as Register)) // POP  reg
+            },
             InstructionPattern(IFTPattern.RegisterWrite(IFTPattern.AnyArgument("reg"))) {
                 inRegisters, _, _, args ->
                 listOf(Instruction.InPlaceInstruction.MoveRR(args["reg"] as Register, inRegisters[0])) // MOV  reg,  reg0
+            },
+            InstructionPattern(IFTPattern.StackPush(IFTPattern.RegisterRead(IFTPattern.AnyArgument("reg")))) {
+                _, _, _, args ->
+                listOf(
+                    Instruction.InPlaceInstruction.PushR(args["reg"] as Register) // PUSH reg
+                )
             },
             InstructionPattern(IFTPattern.StackPush()) {
                 inRegisters, _, _, _ ->

--- a/app/src/main/kotlin/compiler/lowlevel/linearization/InstructionSet.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/linearization/InstructionSet.kt
@@ -1,5 +1,6 @@
 package compiler.lowlevel.linearization
 
+import compiler.intermediate.Constant
 import compiler.intermediate.IFTNode
 import compiler.intermediate.Register
 import compiler.lowlevel.Addressing
@@ -70,7 +71,7 @@ object InstructionSet {
             },
             InstructionPattern(IFTPattern.Const(IFTPattern.AnyArgument("const"))) {
                 _, outRegister, _, args ->
-                listOf(Instruction.InPlaceInstruction.MoveRI(outRegister, args["const"] as Long)) // MOV  out,  const
+                listOf(Instruction.InPlaceInstruction.MoveRI(outRegister, args["const"] as Constant)) // MOV  out,  const
             },
             InstructionPattern(IFTPattern.MemoryWrite()) {
                 inRegisters, _, _, _ ->
@@ -83,7 +84,7 @@ object InstructionSet {
                 )
             ) {
                 _, _, _, args ->
-                listOf(Instruction.InPlaceInstruction.MoveRI(args["reg"] as Register, args["const"] as Long)) // MOV  reg,  const
+                listOf(Instruction.InPlaceInstruction.MoveRI(args["reg"] as Register, args["const"] as Constant)) // MOV  reg,  const
             },
             InstructionPattern(IFTPattern.RegisterWrite(IFTPattern.AnyArgument("reg"))) {
                 inRegisters, _, _, args ->
@@ -360,12 +361,35 @@ object InstructionSet {
                         Instruction.ConditionalJumpInstruction.JmpGtEq(args["target"] as String) // JGE  target
                 )
             },
-            // Instruction for any other node that is used to determine a conditional jump
-            // in practice this should only be register/memory write
-            InstructionPattern(IFTPattern.AnyNode(), setOf(Context.CONDITIONAL)) {
+            InstructionPattern(IFTPattern.MemoryRead(), setOf(Context.CONDITIONAL)) {
                 inRegisters, _, _, args ->
+                val reg = Register() // temporary register
                 listOf(
-                    Instruction.InPlaceInstruction.TestRR(inRegisters[0], inRegisters[0]), //       TEST reg0, reg0
+                    Instruction.InPlaceInstruction.MoveRM(reg, Addressing.Base(inRegisters[0])), // MOV  reg,  [reg0]
+                    Instruction.InPlaceInstruction.TestRR(reg, reg), //                             TEST reg0, reg0
+                    if (args["invert"] as Boolean)
+                        Instruction.ConditionalJumpInstruction.JmpZ(args["target"] as String) //    JZ   target        ; inverted
+                    else
+                        Instruction.ConditionalJumpInstruction.JmpNZ(args["target"] as String) //   JNZ  target
+                )
+            },
+            InstructionPattern(IFTPattern.RegisterRead(IFTPattern.AnyArgument("reg")), setOf(Context.CONDITIONAL)) {
+                _, _, _, args ->
+                val reg = args["reg"] as Register
+                listOf(
+                    Instruction.InPlaceInstruction.TestRR(reg, reg), //                             TEST  reg, reg
+                    if (args["invert"] as Boolean)
+                        Instruction.ConditionalJumpInstruction.JmpZ(args["target"] as String) //    JZ   target        ; inverted
+                    else
+                        Instruction.ConditionalJumpInstruction.JmpNZ(args["target"] as String) //   JNZ  target
+                )
+            },
+            InstructionPattern(IFTPattern.Const(IFTPattern.AnyArgument("const")), setOf(Context.CONDITIONAL)) {
+                _, _, _, args ->
+                val reg = Register() // temporary register
+                listOf(
+                    Instruction.InPlaceInstruction.MoveRI(reg, args["const"] as Constant), //       MOV  reg, const
+                    Instruction.InPlaceInstruction.TestRR(reg, reg), //                             TEST reg, reg
                     if (args["invert"] as Boolean)
                         Instruction.ConditionalJumpInstruction.JmpZ(args["target"] as String) //    JZ   target        ; inverted
                     else

--- a/app/src/main/kotlin/compiler/lowlevel/linearization/InstructionSet.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/linearization/InstructionSet.kt
@@ -165,7 +165,7 @@ object InstructionSet {
                     Instruction.InPlaceInstruction.CallR(
                         inRegisters[0],
                         args["usedRegs"] as Collection<Register> + setOf(inRegisters[0]),
-                        args["definedRegs"] as Collection<Register> + setOf(Register.RSP)
+                        args["definedRegs"] as Collection<Register>
                     ) // CALL reg0
                 )
             },

--- a/app/src/main/kotlin/compiler/lowlevel/linearization/Linearization.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/linearization/Linearization.kt
@@ -31,6 +31,7 @@ object Linearization {
 
         fun dfs(node: IFTNode, nextLabel: String) {
             addLabel(labels[node] ?: assignLabel(node))
+            println("visit $node $nextLabel")
 
             fun addUnconditional() {
                 instructions.addAll(covering.coverUnconditional(node))
@@ -49,6 +50,7 @@ object Linearization {
             }
 
             if (node in cfg.unconditionalLinks) {
+//                println("unconditional")
                 val target = cfg.unconditionalLinks[node]!!
 
                 addUnconditional()
@@ -58,6 +60,7 @@ object Linearization {
                 else
                     dfs(target, nextLabel)
             } else if (node in cfg.conditionalTrueLinks && node in cfg.conditionalFalseLinks) {
+//                println("conditional")
                 val targetWhenTrue = cfg.conditionalTrueLinks[node]!!
                 val targetWhenFalse = cfg.conditionalFalseLinks[node]!!
 
@@ -79,11 +82,18 @@ object Linearization {
             } else if (node in cfg.conditionalTrueLinks || node in cfg.conditionalFalseLinks) {
                 throw IllegalArgumentException() // unreachable state
             } else {
+//                println("ret")
                 addUnconditional() // this must be RET, so no jump is needed
             }
         }
 
         dfs(cfg.entryTreeRoot, "")
+
+//        cfg.unconditionalLinks.entries.forEach { println(it) }
+//        cfg.treeRoots.forEach { println(it) }
+//        instructions.forEach { println(it) }
+//        println(usedLabels)
+//        println()
 
         return instructions.filter { it !is Label || it.label in usedLabels }
     }

--- a/app/src/main/kotlin/compiler/lowlevel/linearization/Linearization.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/linearization/Linearization.kt
@@ -27,30 +27,37 @@ object Linearization {
 
         fun addLabel(label: String) {
             instructions.add(Label(label))
+
+//            println("    ${Label(label)}")
         }
 
         fun dfs(node: IFTNode, nextLabel: String) {
+//            println("visit $node")
             addLabel(labels[node] ?: assignLabel(node))
-            println("visit $node $nextLabel")
 
             fun addUnconditional() {
                 instructions.addAll(covering.coverUnconditional(node))
+
+//                covering.coverUnconditional(node).forEach { println("    $it") }
             }
 
             fun addConditional(whenTrue: Boolean, targetLabel: String) {
                 instructions.addAll(covering.coverConditional(node, targetLabel, !whenTrue))
                 usedLabels.add(targetLabel)
+
+//                covering.coverConditional(node, targetLabel, !whenTrue).forEach { println("    $it") }
             }
 
             fun addJump(targetLabel: String) {
                 if (targetLabel != nextLabel) {
                     instructions.add(Jmp(targetLabel))
                     usedLabels.add(targetLabel)
+
+//                    println("    ${Jmp(targetLabel)}")
                 }
             }
 
             if (node in cfg.unconditionalLinks) {
-//                println("unconditional")
                 val target = cfg.unconditionalLinks[node]!!
 
                 addUnconditional()
@@ -60,7 +67,6 @@ object Linearization {
                 else
                     dfs(target, nextLabel)
             } else if (node in cfg.conditionalTrueLinks && node in cfg.conditionalFalseLinks) {
-//                println("conditional")
                 val targetWhenTrue = cfg.conditionalTrueLinks[node]!!
                 val targetWhenFalse = cfg.conditionalFalseLinks[node]!!
 
@@ -82,18 +88,11 @@ object Linearization {
             } else if (node in cfg.conditionalTrueLinks || node in cfg.conditionalFalseLinks) {
                 throw IllegalArgumentException() // unreachable state
             } else {
-//                println("ret")
                 addUnconditional() // this must be RET, so no jump is needed
             }
         }
 
         dfs(cfg.entryTreeRoot, "")
-
-//        cfg.unconditionalLinks.entries.forEach { println(it) }
-//        cfg.treeRoots.forEach { println(it) }
-//        instructions.forEach { println(it) }
-//        println(usedLabels)
-//        println()
 
         return instructions.filter { it !is Label || it.label in usedLabels }
     }

--- a/app/src/main/kotlin/compiler/lowlevel/linearization/Linearization.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/linearization/Linearization.kt
@@ -27,33 +27,24 @@ object Linearization {
 
         fun addLabel(label: String) {
             instructions.add(Label(label))
-
-//            println("    ${Label(label)}")
         }
 
         fun dfs(node: IFTNode, nextLabel: String) {
-//            println("visit $node")
             addLabel(labels[node] ?: assignLabel(node))
 
             fun addUnconditional() {
                 instructions.addAll(covering.coverUnconditional(node))
-
-//                covering.coverUnconditional(node).forEach { println("    $it") }
             }
 
             fun addConditional(whenTrue: Boolean, targetLabel: String) {
                 instructions.addAll(covering.coverConditional(node, targetLabel, !whenTrue))
                 usedLabels.add(targetLabel)
-
-//                covering.coverConditional(node, targetLabel, !whenTrue).forEach { println("    $it") }
             }
 
             fun addJump(targetLabel: String) {
                 if (targetLabel != nextLabel) {
                     instructions.add(Jmp(targetLabel))
                     usedLabels.add(targetLabel)
-
-//                    println("    ${Jmp(targetLabel)}")
                 }
             }
 

--- a/app/src/main/kotlin/compiler/lowlevel/linearization/Linearization.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/linearization/Linearization.kt
@@ -20,7 +20,7 @@ object Linearization {
         val usedLabels = mutableSetOf<String>()
 
         fun assignLabel(node: IFTNode): String {
-            val label = "_" + labels.size
+            val label = "._" + labels.size
             labels[node] = label
             return label
         }

--- a/app/src/main/kotlin/compiler/lowlevel/storage/DisplayStorage.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/storage/DisplayStorage.kt
@@ -6,6 +6,6 @@ import java.io.PrintWriter
 class DisplayStorage(private val programStaticDepth: Int) {
 
     fun writeAsm(output: PrintWriter) {
-        output.write("$DISPLAY_LABEL_IN_MEMORY: resq $programStaticDepth")
+        output.println("$DISPLAY_LABEL_IN_MEMORY: resq $programStaticDepth")
     }
 }

--- a/app/src/main/kotlin/compiler/lowlevel/storage/GlobalVariableStorage.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/storage/GlobalVariableStorage.kt
@@ -5,6 +5,6 @@ import java.io.PrintWriter
 
 class GlobalVariableStorage(val program: Program) {
     fun writeAsm(output: PrintWriter) {
-        TODO() // Reserve memory for global variables with appropriate initial values
+        output.println("globals:")
     }
 }

--- a/app/src/test/kotlin/compiler/e2e/ArgumentResolverE2eTest.kt
+++ b/app/src/test/kotlin/compiler/e2e/ArgumentResolverE2eTest.kt
@@ -109,6 +109,7 @@ class ArgumentResolverE2eTest {
         )
         assertProgramCorrect(
             """
+                czynność główna() {}
                 czynność f(a: Liczba, b: Liczba, c: Liczba) { }
                 czynność g() {
                     f(c=6, b=1, a=3)

--- a/app/src/test/kotlin/compiler/e2e/CorrectProgramsE2eTest.kt
+++ b/app/src/test/kotlin/compiler/e2e/CorrectProgramsE2eTest.kt
@@ -7,6 +7,7 @@ class CorrectProgramsE2eTest {
     fun `test identifiers`() {
         E2eTestUtils.assertProgramCorrect(
             """
+            czynność główna() {}
             zm n: Liczba = 10234
             zm camelCaseIdentifier: Liczba = 10234
             zm snake_case_identifier: Liczba = 10234
@@ -19,6 +20,7 @@ class CorrectProgramsE2eTest {
     fun `test types and literals`() {
         E2eTestUtils.assertProgramCorrect( // FIXME: the last number literal does not work
             """
+            czynność główna() {}
             czynność typy_i_literały() {
                 zm n: Liczba = 10234
                 n = 0
@@ -39,6 +41,7 @@ class CorrectProgramsE2eTest {
     fun `test if, elif and else`() {
         E2eTestUtils.assertProgramCorrect(
             """
+            czynność główna() {}
             czynność jeśli_zaś_gdy_wpp() {
                 zm x: Liczba
                 zm y: Liczba = 10
@@ -64,6 +67,7 @@ class CorrectProgramsE2eTest {
     fun `test while, break and continue`() {
         E2eTestUtils.assertProgramCorrect(
             """
+            czynność główna() {}
             czynność dopóKI_pomiń_przerwij() {
                 zm x: Liczba = 0
                 dopóki (prawda) { //dopóty
@@ -81,6 +85,7 @@ class CorrectProgramsE2eTest {
     fun `test return`() {
         E2eTestUtils.assertProgramCorrect(
             """
+            czynność główna() {}
             czynność przykład() -> Liczba {
                 zwróć 42
             }
@@ -101,6 +106,7 @@ class CorrectProgramsE2eTest {
     fun `test default arguments`() {
         E2eTestUtils.assertProgramCorrect(
             """
+            czynność główna() {}
             czynność suma(a: Liczba, b: Liczba = 2, c: Liczba = 4, d: Liczba = 8) -> Liczba {
                 zwróć a + b + c + d
             }
@@ -120,6 +126,7 @@ class CorrectProgramsE2eTest {
     fun `test local functions`() {
         E2eTestUtils.assertProgramCorrect(
             """
+            czynność główna() {}
             czynność zewnętrzna() {
                 zm x: Liczba = 10
 
@@ -140,6 +147,7 @@ class CorrectProgramsE2eTest {
     fun `test recurrence`() {
         E2eTestUtils.assertProgramCorrect(
             """
+            czynność główna() {}
             czynność silnia(n: Liczba) -> Liczba {
                 jeśli (n == 0)
                     zwróć 1
@@ -154,6 +162,7 @@ class CorrectProgramsE2eTest {
     fun `test variables, values and constants`() {
         E2eTestUtils.assertProgramCorrect(
             """
+            czynność główna() {}
             czynność zmienne_wartości_stałe() {
                 zm a: Liczba = 2
                 a = 4

--- a/app/src/test/kotlin/compiler/e2e/E2eTestUtils.kt
+++ b/app/src/test/kotlin/compiler/e2e/E2eTestUtils.kt
@@ -3,6 +3,7 @@ package compiler.e2e
 import compiler.Compiler
 import compiler.diagnostics.CompilerDiagnostics
 import compiler.diagnostics.Diagnostic
+import java.io.PrintWriter
 import java.io.StringWriter
 import kotlin.reflect.KClass
 import kotlin.test.assertContentEquals
@@ -15,7 +16,7 @@ object E2eTestUtils {
 
     private fun runProgram(program: String): Sequence<Diagnostic> {
         diagnostics.clear()
-        compiler.process(program.trimIndent().reader(), StringWriter())
+        compiler.process(program.trimIndent().reader(), PrintWriter(StringWriter()))
         return diagnostics.diagnostics
     }
 

--- a/app/src/test/kotlin/compiler/e2e/TypeCheckerE2eTest.kt
+++ b/app/src/test/kotlin/compiler/e2e/TypeCheckerE2eTest.kt
@@ -942,6 +942,7 @@ class TypeCheckerE2eTest {
         )
         assertProgramCorrect(
             """
+                czynność główna() {}
                 czynność f() -> Czy {
                     jeśli (prawda) {
                         jeśli (prawda) {
@@ -970,6 +971,11 @@ class TypeCheckerE2eTest {
                 }
             """
         )
-        assertProgramCorrect("czynność f() -> Czy { { { zwróć prawda;} } }")
+        assertProgramCorrect(
+            """
+                czynność f() -> Czy { { { zwróć prawda;} } } 
+                czynność główna() {}
+            """
+        )
     }
 }

--- a/app/src/test/kotlin/compiler/e2e/TypeCheckerE2eTest.kt
+++ b/app/src/test/kotlin/compiler/e2e/TypeCheckerE2eTest.kt
@@ -161,7 +161,7 @@ class TypeCheckerE2eTest {
         assertProgramCorrect("stała a: Czy = fałsz; czynność główna() {}")
 //        assertProgramCorrect("stała a: Czy = 134 > 43;")
 //        assertProgramCorrect("stała a: Czy = 34 > 7 ? fałsz : 23 == 10;")
-        assertProgramCorrect("stała a: Liczba = 0; czynność główna() {}czynność główna() {}")
+        assertProgramCorrect("stała a: Liczba = 0; czynność główna() {}")
         assertProgramCorrect("stała a: Liczba = 123; czynność główna() {}")
 //        assertProgramCorrect("stała a: Liczba = -17;")
 //        assertProgramCorrect("stała a: Liczba = 10 + 4;")

--- a/app/src/test/kotlin/compiler/e2e/TypeCheckerE2eTest.kt
+++ b/app/src/test/kotlin/compiler/e2e/TypeCheckerE2eTest.kt
@@ -157,12 +157,12 @@ class TypeCheckerE2eTest {
             """
         )
 
-        assertProgramCorrect("stała a: Czy = prawda;")
-        assertProgramCorrect("stała a: Czy = fałsz;")
+        assertProgramCorrect("stała a: Czy = prawda; czynność główna() {}")
+        assertProgramCorrect("stała a: Czy = fałsz; czynność główna() {}")
 //        assertProgramCorrect("stała a: Czy = 134 > 43;")
 //        assertProgramCorrect("stała a: Czy = 34 > 7 ? fałsz : 23 == 10;")
-        assertProgramCorrect("stała a: Liczba = 0;")
-        assertProgramCorrect("stała a: Liczba = 123;")
+        assertProgramCorrect("stała a: Liczba = 0; czynność główna() {}czynność główna() {}")
+        assertProgramCorrect("stała a: Liczba = 123; czynność główna() {}")
 //        assertProgramCorrect("stała a: Liczba = -17;")
 //        assertProgramCorrect("stała a: Liczba = 10 + 4;")
 //        assertProgramCorrect("stała a: Liczba = 1 << 8;")
@@ -216,6 +216,7 @@ class TypeCheckerE2eTest {
 
         assertProgramCorrect(
             """
+                czynność główna() {}
                 czynność f(a: Liczba = 13) { 
                     zakończ
                 }
@@ -223,6 +224,7 @@ class TypeCheckerE2eTest {
         )
         assertProgramCorrect(
             """
+                czynność główna() {}
                 czynność f(a: Czy = fałsz) { 
                     zakończ
                 }
@@ -895,9 +897,15 @@ class TypeCheckerE2eTest {
 
     @Test
     fun `test non Unit function has explicit return at the end`() {
-        assertProgramCorrect("czynność f() -> Nic { zakończ; }")
         assertProgramCorrect(
             """
+                czynność główna() {}
+                czynność f() -> Nic { zakończ; }
+            """
+        )
+        assertProgramCorrect(
+            """
+                czynność główna() {}
                 czynność f() -> Nic {
                     zm a: Liczba = 0
                     a + 1
@@ -906,6 +914,7 @@ class TypeCheckerE2eTest {
         )
         assertProgramCorrect(
             """
+                czynność główna() {}
                 czynność f() -> Liczba {
                     zm a: Liczba = 0
                     zwróć a + 1

--- a/app/src/test/kotlin/compiler/intermediate/ControlFlowGraphBuilderTest.kt
+++ b/app/src/test/kotlin/compiler/intermediate/ControlFlowGraphBuilderTest.kt
@@ -1,5 +1,6 @@
 package compiler.intermediate
 import compiler.utils.referenceHashMapOf
+import compiler.utils.referenceHashSetOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -17,7 +18,7 @@ class ControlFlowGraphBuilderTest {
     private val afterConditionalNode = IFTNode.NoOp()
 
     private val simpleCFG = ControlFlowGraph(
-        treeRoots = listOf(entryNode, secondNode, conditionalTrueNode, conditionalFalseNode),
+        treeRoots = referenceHashSetOf(entryNode, secondNode, conditionalTrueNode, conditionalFalseNode),
         entryTreeRoot = entryNode,
         unconditionalLinks = referenceHashMapOf(entryNode to secondNode),
         conditionalTrueLinks = referenceHashMapOf(secondNode to conditionalTrueNode),
@@ -25,7 +26,7 @@ class ControlFlowGraphBuilderTest {
     )
 
     private val simpleCFGWithExtraFinalNode = ControlFlowGraph(
-        treeRoots = listOf(entryNode, secondNode, conditionalTrueNode, conditionalFalseNode, afterConditionalNode),
+        treeRoots = referenceHashSetOf(entryNode, secondNode, conditionalTrueNode, conditionalFalseNode, afterConditionalNode),
         entryTreeRoot = entryNode,
         unconditionalLinks = referenceHashMapOf(
             entryNode to secondNode,
@@ -41,7 +42,7 @@ class ControlFlowGraphBuilderTest {
         val cfg = ControlFlowGraphBuilder(entryNode).build()
 
         assertEquals(cfg.entryTreeRoot, entryNode)
-        assertEquals(cfg.treeRoots, listOf(entryNode))
+        assertEquals(cfg.treeRoots, referenceHashSetOf<IFTNode>(entryNode))
         assertEquals(cfg.unconditionalLinks, referenceHashMapOf())
         assertEquals(cfg.conditionalFalseLinks, referenceHashMapOf())
         assertEquals(cfg.conditionalTrueLinks, referenceHashMapOf())

--- a/app/src/test/kotlin/compiler/intermediate/ExpressionControlFlowTest.kt
+++ b/app/src/test/kotlin/compiler/intermediate/ExpressionControlFlowTest.kt
@@ -36,6 +36,7 @@ class ExpressionControlFlowTest {
         }
 
         override val spilledRegistersOffset get() = throw NotImplementedError()
+        override val identifier: String get() = throw NotImplementedError()
 
         override fun genRead(namedNode: NamedNode, isDirect: Boolean): IFTNode {
             return IFTNode.DummyRead(namedNode, isDirect)

--- a/app/src/test/kotlin/compiler/intermediate/FunctionControlFlowTest.kt
+++ b/app/src/test/kotlin/compiler/intermediate/FunctionControlFlowTest.kt
@@ -13,6 +13,7 @@ import compiler.diagnostics.Diagnostic.ResolutionDiagnostic.ControlFlowDiagnosti
 import compiler.diagnostics.Diagnostics
 import compiler.utils.ReferenceHashMap
 import compiler.utils.referenceHashMapOf
+import compiler.utils.referenceHashSetOf
 import java.lang.RuntimeException
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -33,7 +34,7 @@ class FunctionControlFlowTest {
 
     private fun getExpressionCFG(expression: Expression, variable: Variable?, function: Function): ControlFlowGraph {
         val node = expressionNodes[expression]?.get(variable)
-        val nodeList = node?.let { listOf(it) } ?: emptyList()
+        val nodeList = node?.let { referenceHashSetOf(it) } ?: referenceHashSetOf()
         return ControlFlowGraph(nodeList, node, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
     }
 
@@ -58,7 +59,7 @@ class FunctionControlFlowTest {
 
         val result = test(program)
 
-        val cfg = ControlFlowGraph(listOf(), null, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
+        val cfg = ControlFlowGraph(referenceHashSetOf(), null, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
         assertEquals(referenceHashMapOf(function to cfg), result)
     }
 
@@ -75,7 +76,7 @@ class FunctionControlFlowTest {
 
         val result = test(program)
 
-        val cfg = ControlFlowGraph(listOf(node), node, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
+        val cfg = ControlFlowGraph(referenceHashSetOf(node), node, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
         assertEquals(referenceHashMapOf(function to cfg), result)
     }
 
@@ -99,7 +100,7 @@ class FunctionControlFlowTest {
         val result = test(program)
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2),
+            referenceHashSetOf(node1, node2),
             node1,
             referenceHashMapOf(node1 to node2),
             referenceHashMapOf(),
@@ -123,7 +124,7 @@ class FunctionControlFlowTest {
 
         val result = test(program)
 
-        val cfg = ControlFlowGraph(listOf(node), node, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
+        val cfg = ControlFlowGraph(referenceHashSetOf(node), node, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
         assertEquals(referenceHashMapOf(function to cfg), result)
     }
 
@@ -146,8 +147,8 @@ class FunctionControlFlowTest {
 
         val result = test(program)
 
-        val cfg = ControlFlowGraph(listOf(node), node, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
-        val nestedCfg = ControlFlowGraph(listOf(), null, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
+        val cfg = ControlFlowGraph(referenceHashSetOf(node), node, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
+        val nestedCfg = ControlFlowGraph(referenceHashSetOf(), null, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
         assertEquals(referenceHashMapOf(function to cfg, nestedFunction to nestedCfg), result)
     }
 
@@ -170,7 +171,7 @@ class FunctionControlFlowTest {
 
         val result = test(program)
 
-        val cfg = ControlFlowGraph(listOf(node), node, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
+        val cfg = ControlFlowGraph(referenceHashSetOf(node), node, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
         assertEquals(referenceHashMapOf(function to cfg), result)
     }
 
@@ -188,7 +189,7 @@ class FunctionControlFlowTest {
 
         val result = test(program)
 
-        val cfg = ControlFlowGraph(listOf(node), node, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
+        val cfg = ControlFlowGraph(referenceHashSetOf(node), node, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
         assertEquals(referenceHashMapOf(function to cfg), result)
     }
 
@@ -215,7 +216,7 @@ class FunctionControlFlowTest {
         val result = test(program)
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2, node3),
+            referenceHashSetOf(node1, node2, node3),
             node1,
             referenceHashMapOf(node2 to node3),
             referenceHashMapOf(node1 to node2),
@@ -252,7 +253,7 @@ class FunctionControlFlowTest {
         val result = test(program)
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2, node3, node4),
+            referenceHashSetOf(node1, node2, node3, node4),
             node1,
             referenceHashMapOf(node2 to node4, node3 to node4),
             referenceHashMapOf(node1 to node2),
@@ -285,7 +286,7 @@ class FunctionControlFlowTest {
         val result = test(program)
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2, node3),
+            referenceHashSetOf(node1, node2, node3),
             node1,
             referenceHashMapOf(node2 to node1),
             referenceHashMapOf(node1 to node2),
@@ -324,7 +325,7 @@ class FunctionControlFlowTest {
         val result = test(program)
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2, node3, node4),
+            referenceHashSetOf(node1, node2, node3, node4),
             node1,
             referenceHashMapOf(node3 to node1),
             referenceHashMapOf(node1 to node2, node2 to node4),
@@ -363,7 +364,7 @@ class FunctionControlFlowTest {
         val result = test(program)
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2, node3, node4),
+            referenceHashSetOf(node1, node2, node3, node4),
             node1,
             referenceHashMapOf(node3 to node1),
             referenceHashMapOf(node1 to node2, node2 to node1),
@@ -406,7 +407,7 @@ class FunctionControlFlowTest {
         val result = test(program)
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2, node3, node4, node5),
+            referenceHashSetOf(node1, node2, node3, node4, node5),
             node1,
             referenceHashMapOf(node4 to node1),
             referenceHashMapOf(node1 to node2, node2 to node5, node3 to node1),
@@ -462,7 +463,7 @@ class FunctionControlFlowTest {
         val result = test(program)
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2, node3, node4, node5, node6, node7, node8),
+            referenceHashSetOf(node1, node2, node3, node4, node5, node6, node7, node8),
             node1,
             referenceHashMapOf(node6 to node3),
             referenceHashMapOf(node1 to node2, node2 to node1, node3 to node4, node4 to node3, node5 to node7, node7 to node8),
@@ -493,7 +494,7 @@ class FunctionControlFlowTest {
         val result = test(program)
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2),
+            referenceHashSetOf(node1, node2),
             node1,
             referenceHashMapOf(),
             referenceHashMapOf(),

--- a/app/src/test/kotlin/compiler/lowlevel/linearization/DynamicCoveringBuilderTest.kt
+++ b/app/src/test/kotlin/compiler/lowlevel/linearization/DynamicCoveringBuilderTest.kt
@@ -14,10 +14,8 @@ class DynamicCoveringBuilderTest {
     private val noOpNode2 = IFTNode.NoOp()
     private val xorNode1 = IFTNode.BitXor(noOpNode1, noOpNode2)
 
-    private fun instructionSetOf(vararg patterns: Pattern): InstructionSet {
-        val instructionSet = mockk<InstructionSet>()
-        every { instructionSet.getInstructionSet() } returns patterns.asList()
-        return instructionSet
+    private fun instructionSetOf(vararg patterns: Pattern): List<Pattern> {
+        return patterns.asList()
     }
 
     private fun matchNodesToPattern(

--- a/app/src/test/kotlin/compiler/lowlevel/linearization/LinearizationTest.kt
+++ b/app/src/test/kotlin/compiler/lowlevel/linearization/LinearizationTest.kt
@@ -7,6 +7,7 @@ import compiler.lowlevel.Instruction
 import compiler.lowlevel.Instruction.UnconditionalJumpInstruction.Jmp
 import compiler.lowlevel.Label
 import compiler.utils.referenceHashMapOf
+import compiler.utils.referenceHashSetOf
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -82,7 +83,7 @@ class LinearizationTest {
 
     @Test
     fun `empty graph`() {
-        val cfg = ControlFlowGraph(emptyList(), null, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
+        val cfg = ControlFlowGraph(referenceHashSetOf(), null, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
 
         val result = Linearization.linearize(cfg, covering)
 
@@ -92,7 +93,7 @@ class LinearizationTest {
     @Test
     fun `single node`() {
         val node = newNode()
-        val cfg = ControlFlowGraph(listOf(node), node, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
+        val cfg = ControlFlowGraph(referenceHashSetOf(node), node, referenceHashMapOf(), referenceHashMapOf(), referenceHashMapOf())
 
         val result = Linearization.linearize(cfg, covering)
 
@@ -105,7 +106,7 @@ class LinearizationTest {
         val node2 = newNode()
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2),
+            referenceHashSetOf(node1, node2),
             node1,
             referenceHashMapOf(node1 to node2),
             referenceHashMapOf(),
@@ -128,7 +129,7 @@ class LinearizationTest {
         val node = newNode()
 
         val cfg = ControlFlowGraph(
-            listOf(node),
+            referenceHashSetOf(node),
             node,
             referenceHashMapOf(node to node),
             referenceHashMapOf(),
@@ -154,7 +155,7 @@ class LinearizationTest {
         val node3 = newNode()
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2, node3),
+            referenceHashSetOf(node1, node2, node3),
             node1,
             referenceHashMapOf(node2 to node3),
             referenceHashMapOf(node1 to node2),
@@ -181,7 +182,7 @@ class LinearizationTest {
         val node3 = newNode()
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2, node3),
+            referenceHashSetOf(node1, node2, node3),
             node1,
             referenceHashMapOf(),
             referenceHashMapOf(node1 to node2),
@@ -210,7 +211,7 @@ class LinearizationTest {
         val node5 = newNode()
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2, node3, node4, node5),
+            referenceHashSetOf(node1, node2, node3, node4, node5),
             node1,
             referenceHashMapOf(),
             referenceHashMapOf(node1 to node2, node3 to node4),
@@ -239,7 +240,7 @@ class LinearizationTest {
         val node2 = newNode()
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2),
+            referenceHashSetOf(node1, node2),
             node1,
             referenceHashMapOf(),
             referenceHashMapOf(node1 to node1),
@@ -264,7 +265,7 @@ class LinearizationTest {
         val node2 = newNode()
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2),
+            referenceHashSetOf(node1, node2),
             node1,
             referenceHashMapOf(),
             referenceHashMapOf(node1 to node2),
@@ -290,7 +291,7 @@ class LinearizationTest {
         val node3 = newNode()
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2, node3),
+            referenceHashSetOf(node1, node2, node3),
             node1,
             referenceHashMapOf(node2 to node1),
             referenceHashMapOf(node1 to node2),
@@ -319,7 +320,7 @@ class LinearizationTest {
         val node3 = newNode()
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2, node3),
+            referenceHashSetOf(node1, node2, node3),
             node1,
             referenceHashMapOf(node2 to node1),
             referenceHashMapOf(node1 to node3),
@@ -348,7 +349,7 @@ class LinearizationTest {
         val node3 = newNode()
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2, node3),
+            referenceHashSetOf(node1, node2, node3),
             node1,
             referenceHashMapOf(),
             referenceHashMapOf(node1 to node2, node2 to node2),
@@ -379,7 +380,7 @@ class LinearizationTest {
         val node4 = newNode()
 
         val cfg = ControlFlowGraph(
-            listOf(node1, node2, node3, node4),
+            referenceHashSetOf(node1, node2, node3, node4),
             node1,
             referenceHashMapOf(node3 to node2),
             referenceHashMapOf(node1 to node2, node2 to node3),


### PR DESCRIPTION
There  are some areas that need work. After changing `ControlFlowGraph.treeRoots` to use `ReferenceHashMap` instead of `List`, current test don't throw errors. However, the code that's generated has some problems:
- The register allocation sometimes uses the `rsp` register which causes segfaults. I don't think there's an option to  ban certain registers from being used in the current code or give a partial coloring in the current code.
- There are probably some bugs in liveness/allocation. For example for the program:
`czynność f() -> Liczba {
    jeśli(prawda)
        zwróć 12
    wpp zwróć 12
}
`
In one of the cases the the instruction `mov rax, 12` is removed from the program despite being generated by linearization. This doesn't happen when the return values are different suggesting some code might be comparing the instructions by value.

I'm also not really sure about how to link the standard library. Currently the location of stdlib.c has to be passed as an argument same as other external code. This is not optimal, but I'm not sure what's the best way to do it. 