### PR TITLE
Refactor the Compiler.process function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ jobs:
       - run:
           name: Test project
           command: |
-            ./gradlew install
             ./test_all.sh --no-daemon
       - save_cache:
           name: Save Gradle to cache

--- a/app/src/main/kotlin/compiler/Compiler.kt
+++ b/app/src/main/kotlin/compiler/Compiler.kt
@@ -2,11 +2,10 @@ package compiler
 
 import compiler.analysis.BuiltinFunctions
 import compiler.analysis.ProgramAnalyzer
-import compiler.ast.Function
 import compiler.ast.Type
 import compiler.diagnostics.Diagnostics
 import compiler.input.ReaderInput
-import compiler.intermediate.ControlFlow.createGraphForProgram
+import compiler.intermediate.ControlFlowPlanner
 import compiler.intermediate.FunctionDependenciesAnalyzer
 import compiler.lexer.Lexer
 import compiler.lowlevel.AsmFile
@@ -39,81 +38,101 @@ class Compiler(val diagnostics: Diagnostics) {
 
     private val lexer = Lexer(LanguageTokens.getTokens(), diagnostics)
     private val parser = Parser(LanguageGrammar.getGrammar(), diagnostics)
+    private val astFactory = AstFactory(diagnostics)
+    private val programAnalyzer = ProgramAnalyzer(diagnostics)
+    private val controlFlowPlanner = ControlFlowPlanner(diagnostics)
     private val covering = DynamicCoveringBuilder(InstructionSet.getInstructionSet())
+    private val allocation = Allocation(ColoringAllocation)
+    private val linearization = Linearization(covering)
 
     fun process(input: Reader, output: Writer): Boolean {
         try {
-            val tokenSequence = lexer.process(ReaderInput(input))
+            // Front-end
 
-            val leaves: Sequence<ParseTree<Symbol>> = tokenSequence.filter { it.category != TokenType.TO_IGNORE } // TODO: move this transformation somewhere else
+            val tokens = lexer.process(ReaderInput(input))
+
+            val tokensAsLeaves: Sequence<ParseTree<Symbol>> = tokens
+                .filter { it.category != TokenType.TO_IGNORE }
                 .map { ParseTree.Leaf(it.location, Symbol.Terminal(it.category), it.content) }
 
-            val parseTree = parser.process(leaves)
+            val parseTree = parser.process(tokensAsLeaves)
 
-            val ast = AstFactory.createFromParseTree(parseTree, diagnostics) // TODO: make AstFactory and Resolver a class for consistency with Lexer and Parser
+            val initialProgram = astFactory.createFromParseTree(parseTree)
 
-            val astWithBuiltinFunctions = BuiltinFunctions.addBuiltinFunctions(ast)
+            val program = BuiltinFunctions.addBuiltinFunctions(initialProgram)
 
-            val programProperties = ProgramAnalyzer.analyzeProgram(astWithBuiltinFunctions, diagnostics)
+            val programProperties = programAnalyzer.analyze(program)
 
             val (functionDetailsGenerators, generatorDetailsGenerators) = FunctionDependenciesAnalyzer.createCallablesDetailsGenerators(
-                astWithBuiltinFunctions,
+                program,
                 programProperties.variableProperties,
                 programProperties.functionReturnedValueVariables,
-                diagnostics.hasAnyError()
-            )
+                diagnostics.hasAnyErrors()
+            ) // NOTE: it probably shouldn't be FunctionDependenciesAnalyzer responsible for this
 
-            val functionCFGs = createGraphForProgram(
-                astWithBuiltinFunctions,
+            val functionControlFlowGraphs = controlFlowPlanner.createGraphsForProgram(
+                program,
                 programProperties,
                 functionDetailsGenerators,
-                generatorDetailsGenerators,
-                diagnostics
+                generatorDetailsGenerators
             )
 
-            val mainFunction = FunctionDependenciesAnalyzer.extractMainFunction(ast, diagnostics)
+            val mainFunction = FunctionDependenciesAnalyzer.extractMainFunction(program, diagnostics) // NOTE: and neither for this
 
-            if (diagnostics.hasAnyError())
+            // Back-end
+
+            if (diagnostics.hasAnyErrors())
                 return false
 
-            val linearFunctions = functionCFGs.mapValues { Linearization.linearize(it.value, covering) }
+            val displayStorage = DisplayStorage(programProperties.staticDepth)
+            val globalVariableStorage = GlobalVariableStorage(program)
 
-            val finalCode = linearFunctions.mapValues {
-                Allocation.allocateRegistersWithSpillsHandling(
-                    it.value,
-                    Liveness.computeLiveness(it.value),
+            val mainFunctionLabel = functionDetailsGenerators[Ref(mainFunction)]!!.identifier
+            val ignoreMainReturnValue = mainFunction!!.returnType != Type.Number
+
+            val foreignIdentifiers = BuiltinFunctions.internallyUsedExternalSymbols +
+                functionDetailsGenerators
+                    .filterKeys { !it.value.isLocal }
+                    .map { it.value.identifier } +
+                generatorDetailsGenerators
+                    .filterKeys { !it.value.isLocal }
+                    .values
+                    .flatMap { listOf(it.initFDG, it.resumeFDG, it.finalizeFDG) }
+                    .map { it.identifier }
+
+            val functions = functionControlFlowGraphs.map { (function, controlFlowGraph) ->
+                val code = linearization.linearize(controlFlowGraph)
+
+                val liveness = Liveness.computeLiveness(code)
+
+                val functionDetailsGenerator = functionDetailsGenerators[function]!!
+
+                val allocationResult = allocation.allocateRegistersWithSpillsHandling(
+                    code,
+                    liveness,
                     Allocation.HARDWARE_REGISTERS,
                     Allocation.AVAILABLE_REGISTERS,
                     Allocation.POTENTIAL_SPILL_HANDLING_REGISTERS,
-                    ColoringAllocation,
-                    functionDetailsGenerators[it.key]!!.spilledRegistersRegionOffset
+                    functionDetailsGenerator.spilledRegistersRegionOffset
                 )
+
+                functionDetailsGenerator.spilledRegistersRegionSize.settledValue = allocationResult.spilledOffset.toLong()
+
+                CodeSection.FunctionCode(functionDetailsGenerator.identifier, allocationResult.code, allocationResult.allocatedRegisters)
             }
 
-            finalCode.entries.forEach { functionDetailsGenerators[it.key]!!.spilledRegistersRegionSize.settledValue = it.value.spilledOffset.toLong() }
+            val codeSection = CodeSection(
+                mainFunctionLabel,
+                ignoreMainReturnValue,
+                foreignIdentifiers,
+                functions
+            )
 
             AsmFile.printFile(
                 PrintWriter(output),
-                DisplayStorage(programProperties.staticDepth)::writeAsm,
-                GlobalVariableStorage(ast)::writeAsm,
-                CodeSection(
-                    functionDetailsGenerators[Ref(mainFunction)]!!.identifier,
-                    mainFunction!!.returnType != Type.Number,
-                    functionDetailsGenerators
-                        .filter { it.key.value.implementation is Function.Implementation.Foreign }
-                        .map { it.value.identifier } +
-                        BuiltinFunctions.internallyUsedExternalSymbols +
-                        generatorDetailsGenerators
-                            .filter { it.key.value.implementation is Function.Implementation.Foreign }
-                            .flatMap { it.value.let { listOf(it.initFDG, it.finalizeFDG, it.resumeFDG) }.map { it.identifier } },
-                    finalCode.map { functionCode ->
-                        functionDetailsGenerators[functionCode.key]!!.identifier to
-                            CodeSection.FunctionCode(
-                                functionCode.value.linearProgram,
-                                functionCode.value.allocatedRegisters
-                            )
-                    }.toMap()
-                )::writeAsm
+                displayStorage::writeAsm,
+                globalVariableStorage::writeAsm,
+                codeSection::writeAsm
             )
 
             return true

--- a/app/src/main/kotlin/compiler/Compiler.kt
+++ b/app/src/main/kotlin/compiler/Compiler.kt
@@ -68,7 +68,7 @@ class Compiler(val diagnostics: Diagnostics) {
                 programProperties.variableProperties,
                 programProperties.functionReturnedValueVariables,
                 diagnostics.hasAnyErrors()
-            ) // NOTE: it probably shouldn't be FunctionDependenciesAnalyzer responsible for this
+            ) // TODO: it probably shouldn't be FunctionDependenciesAnalyzer responsible for this
 
             val functionControlFlowGraphs = controlFlowPlanner.createGraphsForProgram(
                 program,
@@ -77,7 +77,7 @@ class Compiler(val diagnostics: Diagnostics) {
                 generatorDetailsGenerators
             )
 
-            val mainFunction = FunctionDependenciesAnalyzer.extractMainFunction(program, diagnostics) // NOTE: and neither for this
+            val mainFunction = FunctionDependenciesAnalyzer.extractMainFunction(program, diagnostics) // TODO: and neither for this
 
             // Back-end
 

--- a/app/src/main/kotlin/compiler/analysis/ProgramAnalyzer.kt
+++ b/app/src/main/kotlin/compiler/analysis/ProgramAnalyzer.kt
@@ -10,7 +10,7 @@ import compiler.ast.Variable
 import compiler.diagnostics.Diagnostics
 import compiler.utils.Ref
 
-object ProgramAnalyzer {
+class ProgramAnalyzer(private val diagnostics: Diagnostics) {
     data class ProgramProperties(
         val nameResolution: Map<Ref<AstNode>, Ref<NamedNode>>,
         val argumentResolution: Map<Ref<Expression.FunctionCall.Argument>, Ref<Function.Parameter>>,
@@ -21,15 +21,15 @@ object ProgramAnalyzer {
         val staticDepth: Int,
     )
 
-    fun analyzeProgram(ast: Program, diagnostics: Diagnostics): ProgramProperties {
-        val nameResolutionResult = NameResolver.calculateNameResolution(ast, diagnostics)
+    fun analyze(program: Program): ProgramProperties {
+        val nameResolutionResult = NameResolver.calculateNameResolution(program, diagnostics)
         val nameResolution = nameResolutionResult.nameDefinitions
-        val argumentResolution = ArgumentResolver.calculateArgumentToParameterResolution(ast, nameResolution, diagnostics)
-        val expressionTypes = TypeChecker.calculateTypes(ast, nameResolution, argumentResolution.argumentsToParametersMap, diagnostics)
-        val defaultParameterMapping = DefaultParameterResolver.mapFunctionParametersToDummyVariables(ast)
-        InitializationVerifier.verifyAccessedVariablesAreInitialized(ast, nameResolution, defaultParameterMapping, diagnostics)
-        val functionReturnedValueVariables = ReturnValueVariableCreator.createDummyVariablesForFunctionReturnValue(ast)
-        val variableProperties = VariablePropertiesAnalyzer.calculateVariableProperties(ast, nameResolution, defaultParameterMapping, functionReturnedValueVariables, argumentResolution.accessedDefaultValues, diagnostics)
+        val argumentResolution = ArgumentResolver.calculateArgumentToParameterResolution(program, nameResolution, diagnostics)
+        val expressionTypes = TypeChecker.calculateTypes(program, nameResolution, argumentResolution.argumentsToParametersMap, diagnostics)
+        val defaultParameterMapping = DefaultParameterResolver.mapFunctionParametersToDummyVariables(program)
+        InitializationVerifier.verifyAccessedVariablesAreInitialized(program, nameResolution, defaultParameterMapping, diagnostics)
+        val functionReturnedValueVariables = ReturnValueVariableCreator.createDummyVariablesForFunctionReturnValue(program)
+        val variableProperties = VariablePropertiesAnalyzer.calculateVariableProperties(program, nameResolution, defaultParameterMapping, functionReturnedValueVariables, argumentResolution.accessedDefaultValues, diagnostics)
 
         return ProgramProperties(
             nameResolution,

--- a/app/src/main/kotlin/compiler/analysis/ReturnValueVariableCreator.kt
+++ b/app/src/main/kotlin/compiler/analysis/ReturnValueVariableCreator.kt
@@ -14,7 +14,7 @@ object ReturnValueVariableCreator {
         val resultMapping: MutableMap<Ref<Function>, Variable> = mutableKeyRefMapOf()
 
         fun createReturnVariableFor(function: Function) {
-            if (function.implementation is Function.Implementation.Local && function.returnType !is Type.Unit && !function.isGenerator)
+            if (function.isLocal && function.returnType !is Type.Unit && !function.isGenerator)
                 resultMapping[Ref(function)] = Variable(
                     Variable.Kind.VALUE,
                     "_result_dummy_${function.name}",

--- a/app/src/main/kotlin/compiler/analysis/TypeChecker.kt
+++ b/app/src/main/kotlin/compiler/analysis/TypeChecker.kt
@@ -151,7 +151,7 @@ class TypeChecker(private val nameResolution: Map<Ref<AstNode>, Ref<NamedNode>>,
 
         checkBlock(function.body)
 
-        if (function.implementation is Function.Implementation.Local && function.returnType != Type.Unit && !function.isGenerator)
+        if (function.isLocal && function.returnType != Type.Unit && !function.isGenerator)
             checkIfLastStatementIsReturn(function.body)
     }
 

--- a/app/src/main/kotlin/compiler/analysis/VariablePropertiesAnalyzer.kt
+++ b/app/src/main/kotlin/compiler/analysis/VariablePropertiesAnalyzer.kt
@@ -120,7 +120,7 @@ object VariablePropertiesAnalyzer {
                         }
                     }
                     node.body.forEach { analyzeVariables(it, node) }
-                    if (node.implementation is Function.Implementation.Local && node.returnType != Type.Unit && !node.isGenerator) {
+                    if (node.isLocal && node.returnType != Type.Unit && !node.isGenerator) {
                         // Accessed set consists of only the owner function, cause the variable's value is moved to
                         // appropriate Register in the ControlFlowGraph of epilogue of this function, and the Variable
                         // is never accessed anymore (including both outer & inner functions).

--- a/app/src/main/kotlin/compiler/ast/Function.kt
+++ b/app/src/main/kotlin/compiler/ast/Function.kt
@@ -22,6 +22,8 @@ data class Function(
         data class Foreign(val foreignName: String) : Implementation()
     }
 
+    val isLocal: Boolean get() = implementation is Implementation.Local
+
     val body: StatementBlock get() = if (implementation is Implementation.Local) implementation.body else emptyList()
 
     constructor(

--- a/app/src/main/kotlin/compiler/diagnostics/CompilerDiagnostics.kt
+++ b/app/src/main/kotlin/compiler/diagnostics/CompilerDiagnostics.kt
@@ -11,7 +11,7 @@ class CompilerDiagnostics : Diagnostics {
         diagnosticsList.clear()
     }
 
-    override fun hasAnyError() = diagnosticsList.any { it.isError }
+    override fun hasAnyErrors() = diagnosticsList.any { it.isError }
 
     override fun toString() =
         if (diagnosticsList.size > 0) diagnostics.map { it.toString() }.joinToString(separator = "\n")

--- a/app/src/main/kotlin/compiler/diagnostics/Diagnostics.kt
+++ b/app/src/main/kotlin/compiler/diagnostics/Diagnostics.kt
@@ -2,5 +2,5 @@ package compiler.diagnostics
 
 interface Diagnostics {
     fun report(diagnostic: Diagnostic)
-    fun hasAnyError(): Boolean
+    fun hasAnyErrors(): Boolean
 }

--- a/app/src/main/kotlin/compiler/intermediate/FunctionDependenciesAnalyzer.kt
+++ b/app/src/main/kotlin/compiler/intermediate/FunctionDependenciesAnalyzer.kt
@@ -45,7 +45,7 @@ object FunctionDependenciesAnalyzer {
             when (node) {
                 is Program.Global.FunctionDefinition -> { analyze(node.function, pathSoFar) }
                 is Statement.FunctionDefinition -> { analyze(node.function, pathSoFar) }
-                is Function -> if (node.implementation is Function.Implementation.Local) {
+                is Function -> if (node.isLocal) {
                     val newPrefix = nameFunction(node, pathSoFar)
                     var blockNumber = 0
                     fun handleNestedBlock(statements: List<Statement>) = statements.forEach { analyze(it, newPrefix + "@block" + blockNumber++) }

--- a/app/src/main/kotlin/compiler/lowlevel/CodeSection.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/CodeSection.kt
@@ -6,13 +6,13 @@ import java.io.PrintWriter
 class CodeSection(
     private val mainFunctionLabel: String,
     private val ignoreMainReturnValue: Boolean,
-    private val foreignFunctionIdentifiers: List<String>,
-    val functions: Map<String, FunctionCode>
+    private val foreignIdentifiers: List<String>,
+    val functions: List<FunctionCode>
 ) {
-    data class FunctionCode(val instructions: List<Asmable>, val registerAllocation: Map<Register, Register>)
+    data class FunctionCode(val label: String, val instructions: List<Asmable>, val registerAllocation: Map<Register, Register>)
 
     fun writeAsm(output: PrintWriter) {
-        foreignFunctionIdentifiers.forEach { output.println("extern $it") }
+        foreignIdentifiers.forEach { output.println("extern $it") }
 
         output.println(
             """
@@ -24,15 +24,15 @@ class CodeSection(
                     ${if (ignoreMainReturnValue) "xor rax, rax" else "" }
                     pop rbp
                     ret
-                
+
             """.trimIndent()
         )
 
-        functions.forEach { function ->
-            output.println("${function.key}:")
-            function.value.instructions.forEach {
+        functions.forEach { (label, instructions, registerAllocation) ->
+            output.println("$label:")
+            instructions.forEach {
                 output.print("    ")
-                it.writeAsm(output, function.value.registerAllocation)
+                it.writeAsm(output, registerAllocation)
                 output.println()
             }
             output.println()

--- a/app/src/main/kotlin/compiler/lowlevel/linearization/Linearization.kt
+++ b/app/src/main/kotlin/compiler/lowlevel/linearization/Linearization.kt
@@ -8,11 +8,8 @@ import compiler.lowlevel.Label
 import compiler.utils.Ref
 import compiler.utils.mutableKeyRefMapOf
 
-object Linearization {
-    fun linearize(
-        cfg: ControlFlowGraph,
-        covering: Covering,
-    ): List<Asmable> {
+class Linearization(private val covering: Covering) {
+    fun linearize(cfg: ControlFlowGraph): List<Asmable> {
         if (cfg.entryTreeRoot == null)
             return emptyList()
 

--- a/app/src/main/kotlin/compiler/syntax/AstFactory.kt
+++ b/app/src/main/kotlin/compiler/syntax/AstFactory.kt
@@ -16,7 +16,7 @@ import compiler.regex.RegexDfa
 import compiler.syntax.LanguageGrammar.Productions
 import compiler.syntax.utils.TokenRegexParser
 
-object AstFactory {
+class AstFactory(private val diagnostics: Diagnostics) {
     class AstCreationFailed : CompilationFailed()
 
     // helper methods
@@ -37,7 +37,7 @@ object AstFactory {
             skipPassThroughExpressions(parseTree.children.first() as ParseTree.Branch)
     }
 
-    private fun extractIdentifier(parseTree: ParseTree.Branch<Symbol>, diagnostics: Diagnostics): String {
+    private fun extractIdentifier(parseTree: ParseTree.Branch<Symbol>): String {
         val properNode = skipPassThroughExpressions(parseTree)
         if (properNode.production !in listOf(Productions.expr2048Identifier, Productions.eExpr2048Identifier)) {
             diagnostics.report(
@@ -54,7 +54,7 @@ object AstFactory {
 
     private val identifierRegexDfa = RegexDfa(TokenRegexParser.parseStringToRegex("""\l[\l\u\d_]*"""))
 
-    private fun extractForeignName(parseTree: ParseTree.Leaf<Symbol>, diagnostics: Diagnostics, asIdentifier: Boolean): String {
+    private fun extractForeignName(parseTree: ParseTree.Leaf<Symbol>, asIdentifier: Boolean): String {
         return when (parseTree.token()) {
             TokenType.IDENTIFIER -> parseTree.content
             TokenType.FOREIGN_NAME -> {
@@ -90,13 +90,13 @@ object AstFactory {
     }
 
     // node processor methods
-    fun createFromParseTree(parseTree: ParseTree<Symbol>, diagnostics: Diagnostics): Program {
+    fun createFromParseTree(parseTree: ParseTree<Symbol>): Program {
         val children = (parseTree as ParseTree.Branch).getFilteredChildren()
         val globals = children.map {
             when (it.nonTerm()) {
-                NonTerminalType.VAR_DECL -> Program.Global.VariableDefinition(processVariableDeclaration(it, diagnostics), it.location)
-                NonTerminalType.FUNC_DEF -> Program.Global.FunctionDefinition(processFunctionDefinition(it, diagnostics), it.location)
-                NonTerminalType.FOREIGN_DECL -> Program.Global.FunctionDefinition(processForeignFunctionDeclaration(it, diagnostics), it.location)
+                NonTerminalType.VAR_DECL -> Program.Global.VariableDefinition(processVariableDeclaration(it), it.location)
+                NonTerminalType.FUNC_DEF -> Program.Global.FunctionDefinition(processFunctionDefinition(it), it.location)
+                NonTerminalType.FOREIGN_DECL -> Program.Global.FunctionDefinition(processForeignFunctionDeclaration(it), it.location)
                 else -> throw IllegalArgumentException()
             }
         }
@@ -112,7 +112,7 @@ object AstFactory {
         }
     }
 
-    private fun processConst(parseTree: ParseTree<Symbol>, diagnostics: Diagnostics): Expression {
+    private fun processConst(parseTree: ParseTree<Symbol>): Expression {
         val child = (parseTree as ParseTree.Branch).children[0]
 
         return when (child.token()) {
@@ -135,7 +135,7 @@ object AstFactory {
         }
     }
 
-    private fun processVariableDeclaration(parseTree: ParseTree<Symbol>, diagnostics: Diagnostics): Variable {
+    private fun processVariableDeclaration(parseTree: ParseTree<Symbol>): Variable {
         val children = (parseTree as ParseTree.Branch).getFilteredChildren()
 
         val kind = when (children[0].token()) {
@@ -146,37 +146,37 @@ object AstFactory {
         }
         val name = (children[1] as ParseTree.Leaf).content
         val type = processType(children[3])
-        val value = if (children.lastIndex == 5) processExpression(children[5], diagnostics) else null
+        val value = if (children.lastIndex == 5) processExpression(children[5]) else null
 
         return Variable(kind, name, type, value, combineLocations(children))
     }
 
-    private fun processFunctionDefinition(parseTree: ParseTree<Symbol>, diagnostics: Diagnostics): Function {
+    private fun processFunctionDefinition(parseTree: ParseTree<Symbol>): Function {
         val children = (parseTree as ParseTree.Branch).getFilteredChildren()
 
         val isGenerator = children[0].token() == TokenType.GENERATOR
         val name = (children[1] as ParseTree.Leaf).content
-        val parameters = processFunctionDefinitionParameters(children[3], diagnostics)
+        val parameters = processFunctionDefinitionParameters(children[3])
         val returnType = if (children[5].token() == TokenType.ARROW) processType(children[6]) else Type.Unit
-        val body = processManyStatements(children[children.lastIndex - 1], diagnostics)
+        val body = processManyStatements(children[children.lastIndex - 1])
         return Function(name, parameters, returnType, body, isGenerator, combineLocations(children))
     }
 
-    private fun processForeignFunctionDeclaration(parseTree: ParseTree<Symbol>, diagnostics: Diagnostics): Function {
+    private fun processForeignFunctionDeclaration(parseTree: ParseTree<Symbol>): Function {
         val children = (parseTree as ParseTree.Branch).getFilteredChildren()
 
         val isGenerator = children[1].token() == TokenType.GENERATOR
-        val foreignName = extractForeignName(children[2] as ParseTree.Leaf<Symbol>, diagnostics, false)
-        val parameters = processFunctionDefinitionParameters(children[4], diagnostics)
+        val foreignName = extractForeignName(children[2] as ParseTree.Leaf<Symbol>, false)
+        val parameters = processFunctionDefinitionParameters(children[4])
         val returnType = if (children.size > 6 && children[6].token() == TokenType.ARROW) processType(children[7]) else Type.Unit
         val localName = if (children.size > 6 && children[children.size - 2].token() == TokenType.AS)
             (children[children.size - 1] as ParseTree.Leaf).content
         else
-            extractForeignName(children[2] as ParseTree.Leaf<Symbol>, diagnostics, true)
+            extractForeignName(children[2] as ParseTree.Leaf<Symbol>, true)
         return Function(localName, parameters, returnType, Function.Implementation.Foreign(foreignName), isGenerator, parseTree.location)
     }
 
-    private fun processFunctionDefinitionParameters(parseTree: ParseTree<Symbol>, diagnostics: Diagnostics): List<Function.Parameter> {
+    private fun processFunctionDefinitionParameters(parseTree: ParseTree<Symbol>): List<Function.Parameter> {
         val children = (parseTree as ParseTree.Branch).getFilteredChildren()
         val parameters = ArrayList<Function.Parameter>()
         var it = 0
@@ -186,7 +186,7 @@ object AstFactory {
             val type = processType(grandchildren[2])
             val defaultValue = if (it + 1 < children.size && children[it + 1].token() == TokenType.ASSIGNMENT) {
                 it += 4
-                processExpression(children[it - 2], diagnostics)
+                processExpression(children[it - 2])
             } else {
                 it += 2
                 null
@@ -197,19 +197,19 @@ object AstFactory {
         return parameters
     }
 
-    private fun processFunctionCallArguments(parseTree: ParseTree<Symbol>, diagnostics: Diagnostics): List<Expression.FunctionCall.Argument> {
+    private fun processFunctionCallArguments(parseTree: ParseTree<Symbol>): List<Expression.FunctionCall.Argument> {
         val children = (parseTree as ParseTree.Branch).getFilteredChildren()
         val arguments = ArrayList<Expression.FunctionCall.Argument>()
 
         var it = 0
         while (it < children.size) {
             if (it + 1 < children.size && children[it + 1].token() == TokenType.ASSIGNMENT) {
-                val name = extractIdentifier(children[it] as ParseTree.Branch, diagnostics)
-                val value = processExpression(children[it + 2], diagnostics)
+                val name = extractIdentifier(children[it] as ParseTree.Branch)
+                val value = processExpression(children[it + 2])
                 arguments.add(Expression.FunctionCall.Argument(name, value, combineLocations(children[it], children[it + 2])))
                 it += 4
             } else {
-                val value = processExpression(children[it], diagnostics)
+                val value = processExpression(children[it])
                 arguments.add(Expression.FunctionCall.Argument(null, value, children[it].location))
                 it += 2
             }
@@ -272,92 +272,92 @@ object AstFactory {
         Productions.eExpr1024Modulo to Expression.BinaryOperation.Kind.MODULO
     )
 
-    private fun processExpression(parseTree: ParseTree<Symbol>, diagnostics: Diagnostics): Expression {
+    private fun processExpression(parseTree: ParseTree<Symbol>): Expression {
         val properNode = skipPassThroughExpressions(parseTree as ParseTree.Branch)
         val children = properNode.getFilteredChildren()
 
         return when (properNode.production) {
             in listOf(Productions.exprTernary, Productions.eExprTernary) -> {
-                val conditionExpr = processExpression(children[0], diagnostics)
-                val trueBranchExpr = processExpression(children[2], diagnostics)
-                val falseBranchExpr = processExpression(children[4], diagnostics)
+                val conditionExpr = processExpression(children[0])
+                val trueBranchExpr = processExpression(children[2])
+                val falseBranchExpr = processExpression(children[4])
                 Expression.Conditional(conditionExpr, trueBranchExpr, falseBranchExpr, combineLocations(children))
             }
             in binaryOperations.keys -> {
                 val rotatedNode = rotateExpressionLeft(properNode)
                 val newChildren = rotatedNode.getFilteredChildren()
-                val leftExpr = processExpression(newChildren[0], diagnostics)
-                val rightExpr = processExpression(newChildren[2], diagnostics)
+                val leftExpr = processExpression(newChildren[0])
+                val rightExpr = processExpression(newChildren[2])
                 Expression.BinaryOperation(binaryOperations.getValue(rotatedNode.production), leftExpr, rightExpr, combineLocations(children))
             }
             in unaryOperations.keys -> {
-                val subExpr = processExpression(children[1], diagnostics)
+                val subExpr = processExpression(children[1])
                 Expression.UnaryOperation(unaryOperations.getValue(properNode.production), subExpr, combineLocations(children))
             }
             in listOf(Productions.expr2048Call, Productions.eExpr2048Call) -> {
                 val name = (children[0] as ParseTree.Leaf).content
-                val args = processFunctionCallArguments(children[2], diagnostics)
+                val args = processFunctionCallArguments(children[2])
                 Expression.FunctionCall(name, args, combineLocations(children))
             }
             in listOf(Productions.expr2048Identifier, Productions.eExpr2048Identifier) ->
                 Expression.Variable((children[0] as ParseTree.Leaf).content, combineLocations(children))
             in listOf(Productions.expr2048Const, Productions.eExpr2048Const) ->
-                processConst(children[0], diagnostics)
+                processConst(children[0])
             in listOf(Productions.expr2048Parenthesis, Productions.eExpr2048Parenthesis) ->
-                processExpression(children[1], diagnostics)
+                processExpression(children[1])
             else -> throw IllegalArgumentException()
         }
     }
 
-    private fun processManyStatements(parseTree: ParseTree<Symbol>, diagnostics: Diagnostics): StatementBlock {
-        return (parseTree as ParseTree.Branch).getFilteredChildren().map { processStatement(it, diagnostics) }
+    private fun processManyStatements(parseTree: ParseTree<Symbol>): StatementBlock {
+        return (parseTree as ParseTree.Branch).getFilteredChildren().map { processStatement(it) }
     }
 
-    private fun processMaybeBlock(parseTree: ParseTree<Symbol>, diagnostics: Diagnostics): StatementBlock {
+    private fun processMaybeBlock(parseTree: ParseTree<Symbol>): StatementBlock {
         val children = (parseTree as ParseTree.Branch).getFilteredChildren()
 
         return when (parseTree.production) {
             in listOf(Productions.maybeBlockNonBrace, Productions.nonIfMaybeBlockNonBrace) ->
-                listOf(processStatement(children[0], diagnostics))
+                listOf(processStatement(children[0]))
             in listOf(Productions.maybeBlockBraces, Productions.nonIfMaybeBlockBraces) ->
-                processManyStatements(children[1], diagnostics)
+                processManyStatements(children[1])
             else -> throw IllegalArgumentException()
         }
     }
 
-    private fun processIfStatement(parseTree: ParseTree<Symbol>, diagnostics: Diagnostics): Statement {
+    private fun processIfStatement(parseTree: ParseTree<Symbol>): Statement {
         val children = (parseTree as ParseTree.Branch).getFilteredChildren()
 
         val segments = ArrayList<Pair<Expression, StatementBlock>>()
         var it = 0
         while (it < children.size && children[it].token() in listOf(TokenType.IF, TokenType.ELSE_IF)) {
-            val conditionExpr = processExpression(children[it + 2], diagnostics)
-            val bodyBlock = processMaybeBlock(children[it + 4], diagnostics)
+            val conditionExpr = processExpression(children[it + 2])
+            val bodyBlock = processMaybeBlock(children[it + 4])
             segments.add(Pair(conditionExpr, bodyBlock))
             it += 5
         }
-        val elseSegment = if (it < children.size) processMaybeBlock(children[it + 1], diagnostics) else null
+        val elseSegment = if (it < children.size) processMaybeBlock(children[it + 1]) else null
 
         return segments.slice(0 until segments.lastIndex).foldRight(
             Statement.Conditional(segments.last().first, segments.last().second, elseSegment, combineLocations(children))
         ) { segment, elseBranch -> Statement.Conditional(segment.first, segment.second, listOf(elseBranch), combineLocations(children)) }
     }
 
-    private fun processStatement(parseTree: ParseTree<Symbol>, diagnostics: Diagnostics): Statement {
+    private fun processStatement(parseTree: ParseTree<Symbol>): Statement {
         val children = (parseTree as ParseTree.Branch).getFilteredChildren()
 
         return when (parseTree.production) {
             Productions.statementNonBrace ->
-                processStatement(children[0], diagnostics)
+                processStatement(children[0])
             Productions.statementBraces ->
-                Statement.Block(processManyStatements(children[1], diagnostics), combineLocations(children))
+                Statement.Block(processManyStatements(children[1]), combineLocations(children))
             in listOf(Productions.nonBraceStatementAtomic, Productions.nonIfNonBraceStatementAtomic) ->
-                processAtomicStatement(children[0], diagnostics)
+                processAtomicStatement(children[0])
             Productions.nonBraceStatementIf ->
-                processIfStatement(parseTree, diagnostics)
+                processIfStatement(parseTree)
             in listOf(Productions.nonBraceStatementWhile, Productions.nonIfNonBraceStatementWhile) -> {
-                val conditionExpr = processExpression(children[2], diagnostics)
-                val bodyBlock = processMaybeBlock(children[4], diagnostics)
+                val conditionExpr = processExpression(children[2])
+                val bodyBlock = processMaybeBlock(children[4])
                 Statement.Loop(conditionExpr, bodyBlock, combineLocations(children))
             }
             in listOf(Productions.nonBraceStatementForEach, Productions.nonIfNonBraceStatementForEach) -> {
@@ -370,27 +370,27 @@ object AstFactory {
                 )
                 val generatorCall = Expression.FunctionCall(
                     (children[5] as ParseTree.Leaf).content,
-                    processFunctionCallArguments(children[7], diagnostics),
+                    processFunctionCallArguments(children[7]),
                     combineLocations(children.subList(5, 9)),
                 )
-                val action = processMaybeBlock(children[9], diagnostics)
+                val action = processMaybeBlock(children[9])
                 Statement.ForeachLoop(receivingVariable, generatorCall, action, combineLocations(children))
             }
             in listOf(Productions.nonBraceStatementFuncDef, Productions.nonIfNonBraceStatementFuncDef) ->
-                Statement.FunctionDefinition(processFunctionDefinition(children[0], diagnostics), combineLocations(children))
+                Statement.FunctionDefinition(processFunctionDefinition(children[0]), combineLocations(children))
             else -> throw IllegalArgumentException()
         }
     }
 
-    private fun processAtomicStatement(parseTree: ParseTree<Symbol>, diagnostics: Diagnostics): Statement {
+    private fun processAtomicStatement(parseTree: ParseTree<Symbol>): Statement {
         val children = (parseTree as ParseTree.Branch).getFilteredChildren()
 
         return when (parseTree.production) {
             Productions.atomicExpr ->
-                Statement.Evaluation(processExpression(children[0], diagnostics), combineLocations(children))
+                Statement.Evaluation(processExpression(children[0]), combineLocations(children))
             Productions.atomicAssignment -> {
-                val lhsName = extractIdentifier(children[0] as ParseTree.Branch, diagnostics)
-                val rhsExpr = processExpression(children[2], diagnostics)
+                val lhsName = extractIdentifier(children[0] as ParseTree.Branch)
+                val rhsExpr = processExpression(children[2])
                 Statement.Assignment(lhsName, rhsExpr, combineLocations(children))
             }
             Productions.atomicBreak ->
@@ -400,13 +400,13 @@ object AstFactory {
             Productions.atomicReturnUnit ->
                 Statement.FunctionReturn(Expression.UnitLiteral(combineLocations(children)), true, combineLocations(children))
             Productions.atomicReturn ->
-                Statement.FunctionReturn(processExpression(children[1], diagnostics), false, combineLocations(children))
+                Statement.FunctionReturn(processExpression(children[1]), false, combineLocations(children))
             Productions.atomicYield ->
-                Statement.GeneratorYield(processExpression(children[1], diagnostics), combineLocations(children))
+                Statement.GeneratorYield(processExpression(children[1]), combineLocations(children))
             Productions.atomicVarDef ->
-                Statement.VariableDefinition(processVariableDeclaration(children[0], diagnostics), combineLocations(children))
+                Statement.VariableDefinition(processVariableDeclaration(children[0]), combineLocations(children))
             Productions.atomicForeignDecl ->
-                Statement.FunctionDefinition(processForeignFunctionDeclaration(children[0], diagnostics), combineLocations(children))
+                Statement.FunctionDefinition(processForeignFunctionDeclaration(children[0]), combineLocations(children))
             else -> throw IllegalArgumentException()
         }
     }

--- a/app/src/test/kotlin/compiler/analysis/TypeCheckerTest.kt
+++ b/app/src/test/kotlin/compiler/analysis/TypeCheckerTest.kt
@@ -27,7 +27,7 @@ class TypeCheckerTest {
 
     private val diagnostics: Diagnostics = object : Diagnostics {
         override fun report(diagnostic: Diagnostic) { diagnosticsList.add(diagnostic) }
-        override fun hasAnyError(): Boolean = throw RuntimeException("This method should not be called")
+        override fun hasAnyErrors(): Boolean = throw RuntimeException("This method should not be called")
     }
 
     // stała x: Liczba = 123

--- a/app/src/test/kotlin/compiler/intermediate/ExpressionControlFlowPlannerTest.kt
+++ b/app/src/test/kotlin/compiler/intermediate/ExpressionControlFlowPlannerTest.kt
@@ -14,10 +14,10 @@ import compiler.utils.keyRefMapOf
 import compiler.utils.mutableKeyRefMapOf
 import compiler.utils.mutableRefMapOf
 import compiler.utils.refSetOf
+import io.mockk.mockk
 import kotlin.test.Test
 
-class ExpressionControlFlowTest {
-
+class ExpressionControlFlowPlannerTest {
     private class TestFunctionDetailsGenerator(val function: Function) :
         FunctionDetailsGenerator {
         override fun genCall(args: List<IFTNode>): FunctionDetailsGenerator.FunctionCallIntermediateForm {
@@ -105,7 +105,7 @@ class ExpressionControlFlowTest {
         }
 
         fun createCfg(expr: Expression, targetVariable: Variable? = null): ControlFlowGraph {
-            return ControlFlow.createGraphForExpression(
+            return ControlFlowPlanner(mockk()).createGraphForExpression(
                 expr,
                 targetVariable,
                 currentFunction,

--- a/app/src/test/kotlin/compiler/intermediate/FunctionControlFlowPlannerTest.kt
+++ b/app/src/test/kotlin/compiler/intermediate/FunctionControlFlowPlannerTest.kt
@@ -119,7 +119,7 @@ class FunctionControlFlowPlannerTest {
         }
 
         override fun hasAnyErrors(): Boolean {
-            throw RuntimeException("This method shouldn't be called")
+            throw NotImplementedError("This method shouldn't be called")
         }
     }
 

--- a/app/src/test/kotlin/compiler/intermediate/FunctionControlFlowPlannerTest.kt
+++ b/app/src/test/kotlin/compiler/intermediate/FunctionControlFlowPlannerTest.kt
@@ -21,7 +21,7 @@ import compiler.utils.refMapOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class FunctionControlFlowTest {
+class FunctionControlFlowPlannerTest {
     private val expressionNodes = mutableKeyRefMapOf<Expression, MutableMap<Ref<Variable?>, Ref<IFTNode>>>()
     private val expressionAccessNodes = mutableKeyRefMapOf<Expression, MutableMap<Ref<Variable?>, Ref<IFTNode>>>()
     private val nameResolution = mutableRefMapOf<AstNode, NamedNode>()
@@ -113,21 +113,22 @@ class FunctionControlFlowTest {
         }
     }
 
-    private fun test(program: Program) = ControlFlow.createGraphForEachFunction(
+    private val testDiagnostics = object : Diagnostics {
+        override fun report(diagnostic: Diagnostic) {
+            diagnostics.add(diagnostic)
+        }
+
+        override fun hasAnyErrors(): Boolean {
+            throw RuntimeException("This method shouldn't be called")
+        }
+    }
+
+    private fun test(program: Program) = ControlFlowPlanner(testDiagnostics).createGraphsForFunctions(
         program,
         this::getExpressionCFG,
         nameResolution,
         defaultParameterValues,
         functionReturnedValueVariables,
-        object : Diagnostics {
-            override fun report(diagnostic: Diagnostic) {
-                diagnostics.add(diagnostic)
-            }
-
-            override fun hasAnyError(): Boolean {
-                throw RuntimeException("This method shouldn't be called")
-            }
-        },
         { node, variable, _ -> IFTNode.MemoryWrite(IFTNode.MemoryLabel(variable.name), node) },
         dummyGeneratorDetailsGenerator
     )

--- a/app/src/test/kotlin/compiler/intermediate/ProgramControlFlowPlannerTest.kt
+++ b/app/src/test/kotlin/compiler/intermediate/ProgramControlFlowPlannerTest.kt
@@ -1,9 +1,11 @@
 package compiler.intermediate
 
+import io.mockk.mockk
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class ProgramControlFlowTest {
+class ProgramControlFlowPlannerTest {
+    private val controlFlowPlanner = ControlFlowPlanner(mockk())
 
     @Test
     fun `test attachPrologueAndEpilogue for empty function`() {
@@ -11,7 +13,7 @@ class ProgramControlFlowTest {
         val bodyCFG = ControlFlowGraphBuilder().build()
         val epilogue = IFTNode.MemoryLabel("prologue")
 
-        val result = ControlFlow.attachPrologueAndEpilogue(
+        val result = controlFlowPlanner.attachPrologueAndEpilogue(
             bodyCFG,
             ControlFlowGraphBuilder(prologue).build(),
             ControlFlowGraphBuilder(epilogue).build(),
@@ -34,7 +36,7 @@ class ProgramControlFlowTest {
 
         val bodyCFG = ControlFlowGraphBuilder(middleNode).build()
 
-        val result = ControlFlow.attachPrologueAndEpilogue(
+        val result = controlFlowPlanner.attachPrologueAndEpilogue(
             bodyCFG,
             ControlFlowGraphBuilder(prologue).build(),
             ControlFlowGraphBuilder(epilogue).build(),
@@ -64,7 +66,7 @@ class ProgramControlFlowTest {
         bodyCFGBuilder.addLink(Pair(node3, CFGLinkType.CONDITIONAL_FALSE), node4F)
         bodyCFGBuilder.addLink(Pair(node3, CFGLinkType.CONDITIONAL_TRUE), node4T)
 
-        val result = ControlFlow.attachPrologueAndEpilogue(
+        val result = controlFlowPlanner.attachPrologueAndEpilogue(
             bodyCFGBuilder.build(),
             ControlFlowGraphBuilder(prologue).build(),
             ControlFlowGraphBuilder(epilogue).build(),

--- a/app/src/test/kotlin/compiler/lexer/LexerTest.kt
+++ b/app/src/test/kotlin/compiler/lexer/LexerTest.kt
@@ -64,7 +64,7 @@ class LexerTest {
             reports.add(diagnostic)
         }
 
-        override fun hasAnyError() = reports.any { it.isError }
+        override fun hasAnyErrors() = reports.any { it.isError }
     }
 
     @Test fun `empty input results in no tokens`() {

--- a/app/src/test/kotlin/compiler/lowlevel/allocation/AllocationTest.kt
+++ b/app/src/test/kotlin/compiler/lowlevel/allocation/AllocationTest.kt
@@ -45,18 +45,17 @@ class AllocationTest {
             ): PartialAllocation.AllocationResult = PartialAllocation.AllocationResult(mapOf(), listOf())
         }
 
-        val result = Allocation.allocateRegistersWithSpillsHandling(
+        val result = Allocation(allocator).allocateRegistersWithSpillsHandling(
             linearProgram,
             livenessGraphs,
             orderedPhysicalRegisters,
             orderedPhysicalRegisters,
             orderedPhysicalRegisters,
-            allocator,
             variableBlockSize
         )
 
         assertEquals(mapOf(), result.allocatedRegisters)
-        assertEquals(linearProgram, result.linearProgram)
+        assertEquals(linearProgram, result.code)
         assertEquals(0u, result.spilledOffset)
     }
 
@@ -102,13 +101,12 @@ class AllocationTest {
             }
         }
 
-        val result = Allocation.allocateRegistersWithSpillsHandling(
+        val result = Allocation(allocator).allocateRegistersWithSpillsHandling(
             linearProgram,
             livenessGraphs,
             orderedPhysicalRegisters,
             orderedPhysicalRegisters,
             orderedPhysicalRegisters,
-            allocator,
             variableBlockSize
         )
 
@@ -147,7 +145,7 @@ class AllocationTest {
                 linearProgram[2],
                 linearProgram[3],
             ),
-            result.linearProgram
+            result.code
         )
         assertEquals(3u * memoryUnitSize, result.spilledOffset)
     }
@@ -194,13 +192,12 @@ class AllocationTest {
             }
         }
 
-        val result = Allocation.allocateRegistersWithSpillsHandling(
+        val result = Allocation(allocator).allocateRegistersWithSpillsHandling(
             linearProgram,
             livenessGraphs,
             phRegs,
             orderedPhysicalRegisters,
             orderedPhysicalRegisters,
-            allocator,
             variableBlockSize
         )
 
@@ -234,7 +231,7 @@ class AllocationTest {
                 linearProgram[3],
                 linearProgram[4],
             ),
-            result.linearProgram
+            result.code
         )
         assertEquals(3u * memoryUnitSize, result.spilledOffset)
     }
@@ -279,13 +276,12 @@ class AllocationTest {
             }
         }
 
-        val result = Allocation.allocateRegistersWithSpillsHandling(
+        val result = Allocation(allocator).allocateRegistersWithSpillsHandling(
             linearProgram,
             livenessGraphs,
             phRegs,
             allocatablePhysicalRegisters,
             allocatablePhysicalRegisters,
-            allocator,
             variableBlockSize
         )
 
@@ -324,7 +320,7 @@ class AllocationTest {
                 ),
                 linearProgram[3],
             ),
-            result.linearProgram
+            result.code
         )
         assertEquals(2u * memoryUnitSize, result.spilledOffset)
     }

--- a/app/src/test/kotlin/compiler/lowlevel/linearization/LinearizationTest.kt
+++ b/app/src/test/kotlin/compiler/lowlevel/linearization/LinearizationTest.kt
@@ -33,6 +33,8 @@ class LinearizationTest {
         }
     }
 
+    private val linearization = Linearization(covering)
+
     private sealed class AsmablePattern
 
     private class Unconditional(val node: IFTNode) : AsmablePattern()
@@ -93,7 +95,7 @@ class LinearizationTest {
     fun `empty graph`() {
         val cfg = ControlFlowGraph(listOf(), null, refMapOf(), refMapOf(), refMapOf())
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(emptyList(), result)
     }
@@ -103,7 +105,7 @@ class LinearizationTest {
         val node = newNode()
         val cfg = ControlFlowGraph(listOf(node), node, refMapOf(), refMapOf(), refMapOf())
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(listOf(Unconditional(node)), result)
     }
@@ -121,7 +123,7 @@ class LinearizationTest {
             refMapOf()
         )
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(
             listOf(
@@ -144,7 +146,7 @@ class LinearizationTest {
             refMapOf()
         )
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(
             listOf(
@@ -170,7 +172,7 @@ class LinearizationTest {
             refMapOf(node1 to node3)
         )
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(
             listOf(
@@ -197,7 +199,7 @@ class LinearizationTest {
             refMapOf(node1 to node3)
         )
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(
             listOf(
@@ -226,7 +228,7 @@ class LinearizationTest {
             refMapOf(node1 to node3, node3 to node5)
         )
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(
             listOf(
@@ -255,7 +257,7 @@ class LinearizationTest {
             refMapOf(node1 to node2)
         )
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(
             listOf(
@@ -280,7 +282,7 @@ class LinearizationTest {
             refMapOf(node1 to node1)
         )
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(
             listOf(
@@ -306,7 +308,7 @@ class LinearizationTest {
             refMapOf(node1 to node3)
         )
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(
             listOf(
@@ -335,7 +337,7 @@ class LinearizationTest {
             refMapOf(node1 to node2)
         )
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(
             listOf(
@@ -364,7 +366,7 @@ class LinearizationTest {
             refMapOf(node1 to node3, node2 to node1)
         )
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(
             listOf(
@@ -395,7 +397,7 @@ class LinearizationTest {
             refMapOf(node1 to node4, node2 to node1)
         )
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(
             listOf(
@@ -425,7 +427,7 @@ class LinearizationTest {
             emptyMap()
         )
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(
             listOf(
@@ -449,7 +451,7 @@ class LinearizationTest {
             refMapOf()
         )
 
-        val result = Linearization.linearize(cfg, covering)
+        val result = linearization.linearize(cfg)
 
         assertLinearizationMatches(
             listOf(

--- a/app/src/test/kotlin/compiler/parser/ParserTestBase.kt
+++ b/app/src/test/kotlin/compiler/parser/ParserTestBase.kt
@@ -19,7 +19,7 @@ abstract class ParserTestBase {
             else
                 loggedWarnings += 1
         }
-        override fun hasAnyError() = loggedErrors > 0
+        override fun hasAnyErrors() = loggedErrors > 0
     }
 
     fun getMockedDiagnostics(): TestDiagnostics {

--- a/app/src/test/kotlin/compiler/syntax/AstFactoryTest.kt
+++ b/app/src/test/kotlin/compiler/syntax/AstFactoryTest.kt
@@ -24,7 +24,9 @@ class AstFactoryTest {
     // helper procedures
     private val dummyLocation = Location(0, 0)
     private val dummyLocationRange = LocationRange(dummyLocation, dummyLocation)
-    private val dummyDiagnostics = mockk<Diagnostics>()
+    private val diagnostics = mockk<Diagnostics>()
+
+    private val astFactory = AstFactory(diagnostics)
 
     private fun makeNTNode(nonTerminalType: NonTerminalType, production: Production<Symbol>, vararg children: ParseTree<Symbol>): ParseTree<Symbol> =
         ParseTree.Branch(dummyLocationRange, Symbol.NonTerminal(nonTerminalType), children.asList(), production)
@@ -81,7 +83,7 @@ class AstFactoryTest {
         val parseTree = makeNTNode(NonTerminalType.PROGRAM, Productions.program)
         val expectedAst = Program(listOf())
 
-        val resultAst = AstFactory.createFromParseTree(parseTree, dummyDiagnostics)
+        val resultAst = astFactory.createFromParseTree(parseTree)
         assertEquals(expectedAst, resultAst)
     }
 
@@ -112,7 +114,7 @@ class AstFactoryTest {
             )
         )
 
-        val resultAst = AstFactory.createFromParseTree(parseTree, dummyDiagnostics)
+        val resultAst = astFactory.createFromParseTree(parseTree)
         assertEquals(expectedAst, resultAst)
     }
 
@@ -165,7 +167,7 @@ class AstFactoryTest {
             )
         )
 
-        val resultAst = AstFactory.createFromParseTree(parseTree, dummyDiagnostics)
+        val resultAst = astFactory.createFromParseTree(parseTree)
         assertEquals(expectedAst, resultAst)
     }
 
@@ -218,7 +220,7 @@ class AstFactoryTest {
             )
         )
 
-        val resultAst = AstFactory.createFromParseTree(parseTree, dummyDiagnostics)
+        val resultAst = astFactory.createFromParseTree(parseTree)
         assertEquals(expectedAst, resultAst)
     }
 
@@ -409,7 +411,7 @@ class AstFactoryTest {
             )
         )
 
-        val resultAst = AstFactory.createFromParseTree(parseTree, dummyDiagnostics)
+        val resultAst = astFactory.createFromParseTree(parseTree)
         assertEquals(expectedAst, resultAst)
     }
 
@@ -428,8 +430,7 @@ class AstFactoryTest {
             makeTNode(TokenType.NEWLINE, "\n")
         )
 
-        val diagnostics = mockk<Diagnostics>()
-        assertFails { AstFactory.createFromParseTree(parseTree, diagnostics) }
+        assertFails { astFactory.createFromParseTree(parseTree) }
         verify(exactly = 1) { diagnostics.report(ofType(Diagnostic.ParserError.ForeignNameAsInvalidIdentifier::class)) }
     }
 
@@ -464,7 +465,7 @@ class AstFactoryTest {
             )
         )
 
-        val resultAst = AstFactory.createFromParseTree(parseTree, dummyDiagnostics)
+        val resultAst = astFactory.createFromParseTree(parseTree)
         assertEquals(expectedAst, resultAst)
     }
 
@@ -476,9 +477,8 @@ class AstFactoryTest {
             ) wrapUpTo NonTerminalType.EXPR
         )
 
-        val diagnostics = mockk<Diagnostics>()
         every { diagnostics.report(any()) } returns Unit
-        AstFactory.createFromParseTree(parseTree, diagnostics)
+        astFactory.createFromParseTree(parseTree)
         verify(exactly = 1) { diagnostics.report(ofType(Diagnostic.ParserError.InvalidNumberLiteral::class)) }
     }
 
@@ -521,7 +521,7 @@ class AstFactoryTest {
             )
         )
 
-        val resultAst = AstFactory.createFromParseTree(parseTree, dummyDiagnostics)
+        val resultAst = astFactory.createFromParseTree(parseTree)
         assertEquals(expectedAst, resultAst)
     }
 
@@ -571,7 +571,7 @@ class AstFactoryTest {
             )
         )
 
-        val resultAst = AstFactory.createFromParseTree(parseTree, dummyDiagnostics)
+        val resultAst = astFactory.createFromParseTree(parseTree)
         assertEquals(expectedAst, resultAst)
     }
 
@@ -612,7 +612,7 @@ class AstFactoryTest {
             )
         )
 
-        val resultAst = AstFactory.createFromParseTree(parseTree, dummyDiagnostics)
+        val resultAst = astFactory.createFromParseTree(parseTree)
         assertEquals(expectedAst, resultAst)
     }
 
@@ -638,8 +638,7 @@ class AstFactoryTest {
             )
         )
 
-        val diagnostics = mockk<Diagnostics>()
-        assertFails { AstFactory.createFromParseTree(parseTree, diagnostics) }
+        assertFails { astFactory.createFromParseTree(parseTree) }
         verify(exactly = 1) { diagnostics.report(ofType(Diagnostic.ParserError.UnexpectedToken::class)) }
     }
 
@@ -688,7 +687,7 @@ class AstFactoryTest {
             )
         )
 
-        val resultAst = AstFactory.createFromParseTree(parseTree, dummyDiagnostics)
+        val resultAst = astFactory.createFromParseTree(parseTree)
         assertEquals(expectedAst, resultAst)
     }
 
@@ -711,8 +710,7 @@ class AstFactoryTest {
             ) wrapUpTo NonTerminalType.EXPR
         )
 
-        val diagnostics = mockk<Diagnostics>()
-        assertFails { AstFactory.createFromParseTree(parseTree, diagnostics) }
+        assertFails { astFactory.createFromParseTree(parseTree) }
         verify(exactly = 1) { diagnostics.report(ofType(Diagnostic.ParserError.UnexpectedToken::class)) }
     }
 
@@ -760,7 +758,7 @@ class AstFactoryTest {
             )
         )
 
-        val resultAst = AstFactory.createFromParseTree(parseTree, dummyDiagnostics)
+        val resultAst = astFactory.createFromParseTree(parseTree)
         assertEquals(expectedAst, resultAst)
     }
 
@@ -877,7 +875,7 @@ class AstFactoryTest {
             )
         )
 
-        val resultAst = AstFactory.createFromParseTree(parseTree, dummyDiagnostics)
+        val resultAst = astFactory.createFromParseTree(parseTree)
         assertEquals(expectedAst, resultAst)
     }
 
@@ -924,7 +922,7 @@ class AstFactoryTest {
             )
         )
 
-        val resultAst = AstFactory.createFromParseTree(parseTree, dummyDiagnostics)
+        val resultAst = astFactory.createFromParseTree(parseTree)
         assertEquals(expectedAst, resultAst)
     }
 
@@ -995,7 +993,7 @@ class AstFactoryTest {
             )
         )
 
-        val resultAst = AstFactory.createFromParseTree(parseTree, dummyDiagnostics)
+        val resultAst = astFactory.createFromParseTree(parseTree)
         assertEquals(expectedAst, resultAst)
     }
 }

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-./gradlew test "$@"
+./gradlew "$@" test install
 echo "----------------------------------------"
 echo "Running integration tests!"
 echo "----------------------------------------"


### PR DESCRIPTION
This makes `Compiler.process` generally more readable. The interfaces for classes directly used by this function have been slightly changed, mostly by moving `diagnostics` parameter from the used function to its class' constructor. One notable change is that the vague class name `ControlFlow` has been changed to `ControlFlowPlanner` (because that's what this class basically does - it arranges the control flow of the program given its AST).